### PR TITLE
[feat] Auth API 생성 및 인증/인가 처리

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
@@ -1,0 +1,54 @@
+package kakao_tech_bootcamp.community.common;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kakao_tech_bootcamp.community.common.exceptions.UnauthorizedException;
+import kakao_tech_bootcamp.community.service.AuthStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Optional;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+    private final AuthStrategy authStrategy;
+
+    @Autowired
+    public AuthInterceptor(AuthStrategy authStrategy) {
+        this.authStrategy = authStrategy;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if ("/auth".equals(request.getRequestURI()) && "POST".equals(request.getMethod())) {
+            return true; // 로그인 요청만 공개 API
+        }
+
+        String credential = findCredential(request)
+                .orElseThrow(() -> new UnauthorizedException("회원만 접근 가능한 서비스입니다"));
+
+        authStrategy.validate(credential);
+
+        return true;
+    }
+
+    private Optional<String> findCredential(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return Optional.empty();
+        }
+
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("sid")) {
+                return Optional.ofNullable(cookie.getValue());
+            }
+        }
+
+        // 다른 인증 방법 사용 시 Authorization 헤더 처리 코드 필요
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
@@ -41,6 +41,7 @@ public class AuthInterceptor implements HandlerInterceptor {
                 .orElseThrow(() -> new UnauthorizedException("회원만 접근 가능한 서비스입니다"));
 
         AuthInfo authInfo = authStrategy.validate(credential);
+        request.setAttribute("LOGIN_MEMBER", authInfo);
 
         return true;
     }

--- a/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
@@ -9,10 +9,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.util.Map;
 import java.util.Optional;
 
 @Component
 public class AuthInterceptor implements HandlerInterceptor {
+    private static final Map<String, String> PUBLIC_ENDPOINT = Map.of(
+            "/auth", "POST",
+            "/members", "POST",
+            "/members/availability/email", "POST",
+            "/members/availability/nickname", "POST"
+    );
     private final AuthStrategy authStrategy;
 
     @Autowired
@@ -22,8 +29,11 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        if ("/auth".equals(request.getRequestURI()) && "POST".equals(request.getMethod())) {
-            return true; // 로그인 요청만 공개 API
+        String uri = request.getRequestURI();
+        String method = request.getMethod();
+
+        if (PUBLIC_ENDPOINT.containsKey(uri) && PUBLIC_ENDPOINT.get(uri).equals(method)) {
+            return true;
         }
 
         String credential = findCredential(request)

--- a/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kakao_tech_bootcamp.community.common.exceptions.UnauthorizedException;
+import kakao_tech_bootcamp.community.service.AuthInfo;
 import kakao_tech_bootcamp.community.service.AuthStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -39,7 +40,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         String credential = findCredential(request)
                 .orElseThrow(() -> new UnauthorizedException("회원만 접근 가능한 서비스입니다"));
 
-        authStrategy.validate(credential);
+        AuthInfo authInfo = authStrategy.validate(credential);
 
         return true;
     }

--- a/src/main/java/kakao_tech_bootcamp/community/common/CurrentMemberResolver.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/CurrentMemberResolver.java
@@ -1,0 +1,29 @@
+package kakao_tech_bootcamp.community.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
+import kakao_tech_bootcamp.community.service.AuthInfo;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentMemberResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @CurrentMember AuthInfo {변수} 형식의 파라미터만 해석하겠다는 의미
+        return parameter.hasParameterAnnotation(CurrentMember.class) && parameter.getParameterType().equals(AuthInfo.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest)  webRequest.getNativeRequest();
+        return request.getAttribute("LOGIN_MEMBER");
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/common/annotation/CurrentMember.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/annotation/CurrentMember.java
@@ -1,0 +1,11 @@
+package kakao_tech_bootcamp.community.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentMember {
+}

--- a/src/main/java/kakao_tech_bootcamp/community/config/SecurityConfig.java
+++ b/src/main/java/kakao_tech_bootcamp/community/config/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
         return http
                 .csrf(csrf -> csrf.disable())  // REST API 서버이므로 CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // TODO: 개발 편의상 모든 요청 허용. 추후 인증인가 기능 추가 필요
+                        .anyRequest().permitAll()
                 )
                 .httpBasic(basic -> basic.disable())  // REST API 서버임으로 HTTP Basic 비활성화
                 .build();

--- a/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
+++ b/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
@@ -1,22 +1,33 @@
 package kakao_tech_bootcamp.community.config;
 
 import kakao_tech_bootcamp.community.common.AuthInterceptor;
+import kakao_tech_bootcamp.community.common.CurrentMemberResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     private final AuthInterceptor authInterceptor;
+    private final CurrentMemberResolver currentMemberResolver;
 
     @Autowired
-    public WebConfig(AuthInterceptor authInterceptor) {
+    public WebConfig(AuthInterceptor authInterceptor, CurrentMemberResolver currentMemberResolver) {
         this.authInterceptor = authInterceptor;
+        this.currentMemberResolver = currentMemberResolver;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor).addPathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentMemberResolver);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
+++ b/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
@@ -1,0 +1,22 @@
+package kakao_tech_bootcamp.community.config;
+
+import kakao_tech_bootcamp.community.common.AuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthInterceptor authInterceptor;
+
+    @Autowired
+    public WebConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor).addPathPatterns("/**");
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -1,0 +1,46 @@
+package kakao_tech_bootcamp.community.controller;
+
+import kakao_tech_bootcamp.community.common.ApiResponse;
+import kakao_tech_bootcamp.community.dto.AuthRequestDto;
+import kakao_tech_bootcamp.community.service.AuthStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthStrategy authStrategy;
+
+    @Autowired
+    public AuthController(AuthStrategy authStrategy) {
+        this.authStrategy = authStrategy;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> login(@RequestBody @Validated AuthRequestDto authRequestDto) {
+        String sessionId = authStrategy.issue(authRequestDto);
+        ResponseCookie cookie = ResponseCookie.from("sid", sessionId)
+                .httpOnly(true)
+                .sameSite("Strict")
+                .maxAge(60 * 60 * 24 * 7) // 일주일
+                .build();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(SET_COOKIE, cookie.toString())
+                .body(new ApiResponse<>("auth_success", null));
+    }
+
+    @DeleteMapping
+    public ResponseEntity login(@CookieValue("sid") String sessionId) {
+        authStrategy.invalidate(sessionId);
+        ResponseCookie cookie = ResponseCookie.from("sid", sessionId).maxAge(0).build();
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .header(SET_COOKIE, cookie.toString())
+                .build();
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -1,7 +1,9 @@
 package kakao_tech_bootcamp.community.controller;
 
 import kakao_tech_bootcamp.community.common.ApiResponse;
+import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
 import kakao_tech_bootcamp.community.dto.*;
+import kakao_tech_bootcamp.community.service.AuthInfo;
 import kakao_tech_bootcamp.community.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -46,14 +48,16 @@ public class MemberController {
     }
 
     @PatchMapping("/{memberId}")
-    public ResponseEntity modifyMember(@PathVariable Integer memberId, @RequestBody @Validated MemberUpdateRequestDto updateMemberRequestDto) {
-        memberService.modifyMember(memberId, updateMemberRequestDto);
+    public ResponseEntity modifyMember(@CurrentMember AuthInfo authInfo,
+                                       @PathVariable Integer memberId,
+                                       @RequestBody @Validated MemberUpdateRequestDto updateMemberRequestDto) {
+        memberService.modifyMember(authInfo.getId(), memberId, updateMemberRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping("/{memberId}")
-    public ResponseEntity removeMember(@PathVariable Integer memberId) {
-        memberService.removeMember(memberId);
+    public ResponseEntity removeMember(@CurrentMember AuthInfo authInfo, @PathVariable Integer memberId) {
+        memberService.removeMember(authInfo.getId(), memberId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/AuthRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/AuthRequestDto.java
@@ -1,0 +1,16 @@
+package kakao_tech_bootcamp.community.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class AuthRequestDto {
+    @Email(message = "이메일 형식이 유효하지 않습니다")
+    @Size(max = 50, message = "이메일 형식이 유효하지 않습니다")
+    private String email;
+
+    @Pattern(regexp = "^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9])(?=.*?[~.!@#$%^&*()_\\-+=\\[\\]{}|\\\\;:'\",?/]).{8,20}$", message = "비밀번호 형식이 유효하지 않습니다")
+    private String password;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
@@ -1,6 +1,5 @@
 package kakao_tech_bootcamp.community.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import kakao_tech_bootcamp.community.entity.Image;
 import lombok.Getter;
@@ -10,7 +9,6 @@ public class MemberUpdateRequestDto {
     @Pattern(regexp = "^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9])(?=.*?[~.!@#$%^&*()_\\-+=\\[\\]{}|\\\\;:'\",?/]).{8,20}$", message = "비밀번호 형식이 유효하지 않습니다")
     private String password;
 
-    @NotBlank(message = "비밀번호가 일치하지 않습니다")
     private String confirmedPassword;
 
     @Pattern(regexp = "^\\S{1,10}$", message = "닉네임 형식이 유효하지 않습니다")

--- a/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
@@ -4,9 +4,13 @@ import kakao_tech_bootcamp.community.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Integer> {
     public boolean existsByEmail(String email);
 
     public boolean existsByNickname(String nickname);
+
+    public Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
@@ -20,8 +20,7 @@ public class SessionRepository {
         return Optional.ofNullable(sessions.get(sessionId));
     }
 
-    // JpaRepository와의 통일성 위해 리턴 값 Optional로 감쌈
-    public Optional<Session> delete(String sessionId) {
-        return Optional.ofNullable(sessions.remove(sessionId));
+    public void delete(String sessionId) {
+        sessions.remove(sessionId);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
@@ -1,6 +1,6 @@
 package kakao_tech_bootcamp.community.repository;
 
-import kakao_tech_bootcamp.community.service.Session;
+import kakao_tech_bootcamp.community.service.AuthInfo;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
@@ -9,14 +9,14 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class SessionRepository {
-    private final Map<String, Session> sessions = new ConcurrentHashMap<>();
+    private final Map<String, AuthInfo> sessions = new ConcurrentHashMap<>();
 
-    public void save(String sessionId, Session session) {
+    public void save(String sessionId, AuthInfo session) {
         sessions.putIfAbsent(sessionId, session);
     }
 
     // JpaRepository와의 통일성 위해 리턴 값 Optional로 감쌈
-    public Optional<Session> findById(String sessionId) {
+    public Optional<AuthInfo> findById(String sessionId) {
         return Optional.ofNullable(sessions.get(sessionId));
     }
 

--- a/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
@@ -1,0 +1,27 @@
+package kakao_tech_bootcamp.community.repository;
+
+import kakao_tech_bootcamp.community.service.Session;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class SessionRepository {
+    private final Map<String, Session> sessions = new ConcurrentHashMap<>();
+
+    public void save(String sessionId, Session session) {
+        sessions.putIfAbsent(sessionId, session);
+    }
+
+    // JpaRepository와의 통일성 위해 리턴 값 Optional로 감쌈
+    public Optional<Session> findById(String sessionId) {
+        return Optional.ofNullable(sessions.get(sessionId));
+    }
+
+    // JpaRepository와의 통일성 위해 리턴 값 Optional로 감쌈
+    public Optional<Session> delete(String sessionId) {
+        return Optional.ofNullable(sessions.remove(sessionId));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthInfo.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthInfo.java
@@ -5,13 +5,13 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class Session {
-    private String email;
+public class AuthInfo {
+    private Integer id;
     private LocalDateTime createdAt;
     private LocalDateTime expiredAt;
 
-    public Session(String email) {
-        this.email = email;
+    public AuthInfo(Integer id) {
+        this.id = id;
         createdAt = LocalDateTime.now();
         expiredAt = createdAt.plusDays(7);
     }

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
@@ -1,0 +1,66 @@
+package kakao_tech_bootcamp.community.service;
+
+import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
+import kakao_tech_bootcamp.community.common.exceptions.UnauthorizedException;
+import kakao_tech_bootcamp.community.dto.AuthRequestDto;
+import kakao_tech_bootcamp.community.entity.Member;
+import kakao_tech_bootcamp.community.repository.SessionRepository;
+import kakao_tech_bootcamp.community.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class AuthSessionStrategy implements AuthStrategy {
+    private final SessionRepository sessionRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public AuthSessionStrategy(SessionRepository sessionRepository, MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+        this.sessionRepository = sessionRepository;
+        this.memberRepository = memberRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public String issue(AuthRequestDto dto) {
+        Member member = memberRepository.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
+
+        /*
+         회원을 인증할 수 없다는 401이 논리적으로 옳을 수 있지만
+         보안을 고려하여 이메일/비밀번호 중 무엇이 틀렸는지 힌트를 주지 않기 위해 404로 통일
+         */
+        if (!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
+            throw new NotFoundException("회원을 찾을 수 없습니다");
+        }
+
+        String sessionId = UUID.randomUUID().toString();
+        Session session = new Session(dto.getEmail());
+
+        sessionRepository.save(sessionId, session);
+
+        return sessionId;
+    }
+
+    @Override
+    public String validate(String credential) {
+        Session session = sessionRepository.findById(credential)
+                .orElseThrow(() -> new NotFoundException("인증 정보를 찾을 수 없습니다"));
+
+        if (session.isExpired()) {
+            sessionRepository.delete(credential);
+            throw new UnauthorizedException("인증 정보가 만료됐습니다");
+        }
+
+        return session.getEmail();
+    }
+
+    @Override
+    public void invalidate(String credential) {
+        sessionRepository.delete(credential).orElseThrow(() -> new NotFoundException("인증 정보를 찾을 수 없습니다"));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
@@ -39,7 +39,7 @@ public class AuthSessionStrategy implements AuthStrategy {
         }
 
         String sessionId = UUID.randomUUID().toString();
-        Session session = new Session(dto.getEmail());
+        AuthInfo session = new AuthInfo(member.getId());
 
         sessionRepository.save(sessionId, session);
 
@@ -47,8 +47,8 @@ public class AuthSessionStrategy implements AuthStrategy {
     }
 
     @Override
-    public String validate(String credential) {
-        Session session = sessionRepository.findById(credential)
+    public AuthInfo validate(String credential) {
+        AuthInfo session = sessionRepository.findById(credential)
                 .orElseThrow(() -> new NotFoundException("인증 정보를 찾을 수 없습니다"));
 
         if (session.isExpired()) {
@@ -56,7 +56,7 @@ public class AuthSessionStrategy implements AuthStrategy {
             throw new UnauthorizedException("인증 정보가 만료됐습니다");
         }
 
-        return session.getEmail();
+        return session;
     }
 
     @Override

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
@@ -61,6 +61,7 @@ public class AuthSessionStrategy implements AuthStrategy {
 
     @Override
     public void invalidate(String credential) {
-        sessionRepository.delete(credential).orElseThrow(() -> new NotFoundException("인증 정보를 찾을 수 없습니다"));
+        // 로그아웃하는 상황에 만약 sessionRepository에 삭제할 세션ID가 없더라도 404 에러를 낼 이유가 없음
+        sessionRepository.delete(credential);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthStrategy.java
@@ -1,0 +1,11 @@
+package kakao_tech_bootcamp.community.service;
+
+import kakao_tech_bootcamp.community.dto.AuthRequestDto;
+
+public interface AuthStrategy {
+    String issue(AuthRequestDto dto);
+
+    String validate(String credential);
+
+    void invalidate(String credential);
+}

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthStrategy.java
@@ -5,7 +5,7 @@ import kakao_tech_bootcamp.community.dto.AuthRequestDto;
 public interface AuthStrategy {
     String issue(AuthRequestDto dto);
 
-    String validate(String credential);
+    AuthInfo validate(String credential);
 
     void invalidate(String credential);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -1,6 +1,5 @@
 package kakao_tech_bootcamp.community.service;
 
-import jakarta.transaction.Transactional;
 import kakao_tech_bootcamp.community.common.exceptions.BadRequestException;
 import kakao_tech_bootcamp.community.common.exceptions.ConflictException;
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
@@ -13,8 +12,10 @@ import kakao_tech_bootcamp.community.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -25,21 +26,20 @@ public class MemberService {
         this.passwordEncoder = passwordEncoder;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public void existsByEmail(MemberAvailabilityDto memberAvailabilityDto) {
         if (memberRepository.existsByEmail(memberAvailabilityDto.getEmail())) {
             throw new ConflictException("중복된 이메일입니다");
         }
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public void existsByNickname(MemberAvailabilityDto memberAvailabilityDto) {
         if (memberRepository.existsByNickname(memberAvailabilityDto.getNickname())) {
             throw new ConflictException("중복된 닉네임입니다");
         }
     }
 
-    @Transactional
     public void saveMember(MemberCreateRequestDto dto) {
         if (!dto.getPassword().equals(dto.getConfirmedPassword())) {
             throw new BadRequestException("비밀번호가 일치하지 않습니다");
@@ -59,7 +59,7 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public MemberResponseDto findMember(Integer id) {
         Member member = memberRepository.findById(id).orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
@@ -73,7 +73,6 @@ public class MemberService {
         return memberResponseDto;
     }
 
-    @Transactional
     public void modifyMember(Integer id, MemberUpdateRequestDto dto) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
@@ -95,7 +94,6 @@ public class MemberService {
         }
     }
 
-    @Transactional
     public void removeMember(Integer id) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -2,6 +2,7 @@ package kakao_tech_bootcamp.community.service;
 
 import kakao_tech_bootcamp.community.common.exceptions.BadRequestException;
 import kakao_tech_bootcamp.community.common.exceptions.ConflictException;
+import kakao_tech_bootcamp.community.common.exceptions.ForbiddenException;
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
 import kakao_tech_bootcamp.community.dto.MemberAvailabilityDto;
 import kakao_tech_bootcamp.community.dto.MemberCreateRequestDto;
@@ -73,7 +74,11 @@ public class MemberService {
         return memberResponseDto;
     }
 
-    public void modifyMember(Integer id, MemberUpdateRequestDto dto) {
+    public void modifyMember(Integer currentMemberId, Integer id, MemberUpdateRequestDto dto) {
+        if (currentMemberId != id) {
+            throw new ForbiddenException("회원 본인 정보에 대해서만 수정할 수 있습니다");
+        }
+
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
@@ -86,7 +91,7 @@ public class MemberService {
                 throw new BadRequestException("비밀번호가 일치하지 않습니다");
             }
 
-            member.setPassword(dto.getPassword());
+            member.setPassword(passwordEncoder.encode(dto.getPassword()));
         }
 
         if (dto.getImage() != null) {
@@ -94,7 +99,11 @@ public class MemberService {
         }
     }
 
-    public void removeMember(Integer id) {
+    public void removeMember(Integer currentMemberId, Integer id) {
+        if (currentMemberId != id) {
+            throw new ForbiddenException("회원 본인만 탈퇴할 수 있습니다");
+        }
+
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
         memberRepository.delete(member);

--- a/src/main/java/kakao_tech_bootcamp/community/service/Session.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/Session.java
@@ -1,0 +1,22 @@
+package kakao_tech_bootcamp.community.service;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Session {
+    private String email;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiredAt;
+
+    public Session(String email) {
+        this.email = email;
+        createdAt = LocalDateTime.now();
+        expiredAt = createdAt.plusDays(7);
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiredAt);
+    }
+}


### PR DESCRIPTION
## 작업 내용

- AuthRequestDto 생성 및 Validation 적용
- Auth Controller, Auth Strategy, Auth Repository 작성
    - 세션 기반 인증 방식 선택
    - 세션ID는 데이터베이스가 아니라, ConcurrentHashMap 메모리 변수에서 관리
    - 추후 토큰 방식으로의 확장까지 고려해 전략 패턴 활용
- AuthInterceptor로 `sid` 쿠키 존재 여부 및 유효성 검증하여 인증 작업 진행
- ArgumentResolver로 인증 정보를 Controller에서 파라미터로 받을 수 있도록 작업
    - AuthInfo 클래스 타입을 받는 CurrentMember 커스텀 어노테이션 생성
- Member API 중 회원 수정과 탈퇴 요청 시 해당 작업을 당하는 회원과 현재 로그인한 회원이 같은지 확인하는 로직 추가
    - 불일치 시 403 Forbidden 예외 발생

<br>
<br>
<br>

## 고민 내용

### 토큰 기반 인증 VS 세션 기반 인증
- 원래 JWT 토큰 희망
    - Stateless
    - 일부 Stateful하긴 하지만 세션보다 네트워크 통신 비용 절감
        - Redis 등 데이터베이스로 로그아웃/탈퇴한 AccessToken 블랙리스트나 RefreshToken 저장 및 관리 → Stateful
        - 그러나 AccessToken 미만료 시 RefreshToken, 즉 데이터베이스 접근 필요 X
- 로그인 구현 방식보다 더 깊이 고민할 부분이 많다고 판단
    - 제대로 이해하기 위해선 JWT 학습 및 자바로 구현하는 데 꽤 긴 시간 소요 예상 → 시간 부족 이슈
    - 그렇다고 어줍잖게 알아보고 단순히 동작하는 코드 작성하는 건 시간 낭비
    - 추가로 7주차에 JWT를 배우니 본과제에서 토큰이 집중할 요소가 아니라고 생각
- **결론** ⇒ 우선 확실히 구현할 수 있는 세션 기반으로 빠르게 구현 완료하자
    - Redis 사용하면 좋겠지만 무경험 이슈로 간단히 메모리 변수를 데이터베이스로 활용
    - 과제 마무리 후 시간이 된다면 토큰 기반으로 리팩토링 시도
        - 전략 패턴 적용해 토큰 기반으로 확장할 수 있도록 설계함

<br>

### 로그인 시 비밀번호 불일치한 경우에도 404 예외 처리
- 이메일은 있지만 비밀번호만 잘못 입력한 경우엔 401이 논리적으로 옳다고 생각하지만
- 보안을 고려해 잘못 입력한 게 이메일인지, 비밀번호인지 아님 아예 회원가입이 안 돼 있는 건지 유추할 수 없도록 404 예외로 처리
    - 현재 기획서엔 없지만 비밀번호 재설정 기능이 있다면 그걸로 이곳 회원인지 아닌지 알아낼 수 있긴 함...

<br>

### SpringSecurity와 @AuthenticationPrincipal VS AuthInterceptor 커스터마이징과 `@CurrentMember` 커스텀 어노테이션
- Spring만으로 벅찬데 이런저런 설정이 필요한 SpringSecurity까지?
    - 돌아가는 코드 작성에 매몰되긴 싫음 → 내가 더 이해하기 쉬운 커스터마이징 방식 선택
        - 커스터마이징 방식 덕분에 컴포넌트, 리졸버, 인터셉터 등 스프링을 파악하는 데 도움됐음
- SpringSecurity 설정 완벽 이해 및 활용이 본 과제의 본질은 아니라고 생각

<br>

### AuthInfo 클래스에 `memberId`를 넣어도 되는가?
- 회원 id가 민감한 정보인가? → 그렇긴 함. 그럼 id 대신 이메일을 넣으면 더 보안적으로 안전한가? → 잘 모르겠음
    - id든 이메일든 공격자에게 유출되면 동일하게 악용 가능하지 않나?
    - AuthInfo에 이메일을 넣더라도, 결국 그 인증 정보를 가진 공격자가 어떤 요청을 날리면 그대로 비즈니스 로직이 동작하는데
- 반면 이메일을 AuthInfo에 넣으면 **데이터베이스 접근 횟수가 추가된다는 확실한 단점 존재**
    - 예를 들어 `@CurrentMember`로 AuthInfo 받더라도 게시글 삭제 요청 시 게시글 작성자의 id와 로그인한 회원의 id를 비교하기 위해 데이터베이스에서 `findByEmail()`로 회원 정보 조회 필요
- 보안적 위험이 비슷하다고 보이므로 데이터베이스 접근을 덜할 수 있는 id를 AuthInfo에 담기로 결정

<br>
<br>
<br>

## 화면 캡처
- 로그인 시 쿠키에 sid 생성
    <img width="787" height="344" alt="image" src="https://github.com/user-attachments/assets/d432b5be-30be-4ddc-b617-92739c83c7bc" />

- 로그인 안 한 경우 401
    <img width="576" height="238" alt="image" src="https://github.com/user-attachments/assets/297403a0-a189-467b-8435-3fecedc46803" />

- 로그인한 회원과 회원 정보를 수정/삭제할 회원이 일치하지 않으면 403
    <img width="583" height="243" alt="image" src="https://github.com/user-attachments/assets/3273bcbd-6456-4a78-af55-ca5eb0a6b2fb" />

- 로그아웃 (캡쳐에선 응답이 202이지만, 204로 수정 완료함)
    <img width="473" height="164" alt="image" src="https://github.com/user-attachments/assets/b43ec247-0ded-4d13-940c-54d72cff0c95" />