### PR TITLE
[feat] Image API 및 기존 회원에 Auth 처리 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 application-secret.yml
+
+s3/

--- a/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
@@ -19,7 +19,8 @@ public class AuthInterceptor implements HandlerInterceptor {
             "/auth", "POST",
             "/members", "POST",
             "/members/availability/email", "POST",
-            "/members/availability/nickname", "POST"
+            "/members/availability/nickname", "POST",
+            "/images/members", "POST"
     );
     private final AuthStrategy authStrategy;
 

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
     public ResponseEntity login(@CookieValue("sid") String sessionId) {
         authStrategy.invalidate(sessionId);
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId).maxAge(0).build();
-        return ResponseEntity.status(HttpStatus.ACCEPTED)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .header(SET_COOKIE, cookie.toString())
                 .build();
     }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse> login(@RequestBody @Validated AuthRequestDto authRequestDto) {
+    public ResponseEntity<ApiResponse> logout(@RequestBody @Validated AuthRequestDto authRequestDto) {
         String sessionId = authStrategy.issue(authRequestDto);
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId)
                 .httpOnly(true)
@@ -36,7 +36,7 @@ public class AuthController {
     }
 
     @DeleteMapping
-    public ResponseEntity login(@CookieValue("sid") String sessionId) {
+    public ResponseEntity logout(@CookieValue("sid") String sessionId) {
         authStrategy.invalidate(sessionId);
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId).maxAge(0).build();
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
@@ -1,0 +1,36 @@
+package kakao_tech_bootcamp.community.controller;
+
+import kakao_tech_bootcamp.community.common.ApiResponse;
+import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
+import kakao_tech_bootcamp.community.dto.ImageResponseDto;
+import kakao_tech_bootcamp.community.service.AuthInfo;
+import kakao_tech_bootcamp.community.service.ImageService;
+import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Log
+@RestController
+@RequestMapping("/images")
+public class ImageController {
+    private final ImageService imageService;
+
+    @Autowired
+    public ImageController(ImageService localImageService) {
+        this.imageService = localImageService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> upload(@CurrentMember AuthInfo authInfo,
+                                              @RequestParam("type") String type,
+                                              @RequestParam("file") MultipartFile file) throws IOException {
+        ImageResponseDto imageResponseDto = imageService.saveImage(authInfo.getId(), type, file);
+        Map<String, ImageResponseDto> data = Map.of("image", imageResponseDto);
+        return ResponseEntity.ok(new ApiResponse<>("upload_success", data));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
@@ -6,6 +6,7 @@ import kakao_tech_bootcamp.community.dto.ImageResponseDto;
 import kakao_tech_bootcamp.community.service.AuthInfo;
 import kakao_tech_bootcamp.community.service.ImageService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,13 +28,13 @@ public class ImageController {
     public ResponseEntity<ApiResponse> saveMemberImage(@RequestParam("file") MultipartFile file) throws IOException {
         ImageResponseDto imageResponseDto = imageService.saveImage("members", file);
         Map<String, ImageResponseDto> data = Map.of("image", imageResponseDto);
-        return ResponseEntity.ok(new ApiResponse<>("upload_success", data));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("upload_success", data));
     }
 
     @PostMapping("/posts")
     public ResponseEntity<ApiResponse> savePostImage(@CurrentMember AuthInfo authInfo, @RequestParam("file") MultipartFile file) throws IOException {
         ImageResponseDto imageResponseDto = imageService.saveImage("posts", file);
         Map<String, ImageResponseDto> data = Map.of("image", imageResponseDto);
-        return ResponseEntity.ok(new ApiResponse<>("upload_success", data));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("upload_success", data));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
@@ -5,7 +5,6 @@ import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
 import kakao_tech_bootcamp.community.dto.ImageResponseDto;
 import kakao_tech_bootcamp.community.service.AuthInfo;
 import kakao_tech_bootcamp.community.service.ImageService;
-import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,7 +13,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.Map;
 
-@Log
 @RestController
 @RequestMapping("/images")
 public class ImageController {
@@ -25,11 +23,16 @@ public class ImageController {
         this.imageService = localImageService;
     }
 
-    @PostMapping
-    public ResponseEntity<ApiResponse> upload(@CurrentMember AuthInfo authInfo,
-                                              @RequestParam("type") String type,
-                                              @RequestParam("file") MultipartFile file) throws IOException {
-        ImageResponseDto imageResponseDto = imageService.saveImage(authInfo.getId(), type, file);
+    @PostMapping("/members")
+    public ResponseEntity<ApiResponse> saveMemberImage(@RequestParam("file") MultipartFile file) throws IOException {
+        ImageResponseDto imageResponseDto = imageService.saveImage("members", file);
+        Map<String, ImageResponseDto> data = Map.of("image", imageResponseDto);
+        return ResponseEntity.ok(new ApiResponse<>("upload_success", data));
+    }
+
+    @PostMapping("/posts")
+    public ResponseEntity<ApiResponse> savePostImage(@CurrentMember AuthInfo authInfo, @RequestParam("file") MultipartFile file) throws IOException {
+        ImageResponseDto imageResponseDto = imageService.saveImage("posts", file);
         Map<String, ImageResponseDto> data = Map.of("image", imageResponseDto);
         return ResponseEntity.ok(new ApiResponse<>("upload_success", data));
     }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -52,7 +52,7 @@ public class MemberController {
                                        @PathVariable Integer memberId,
                                        @RequestBody @Validated MemberUpdateRequestDto updateMemberRequestDto) {
         memberService.modifyMember(authInfo.getId(), memberId, updateMemberRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @DeleteMapping("/{memberId}")

--- a/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
@@ -1,0 +1,12 @@
+package kakao_tech_bootcamp.community.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class ImageReferenceDto {
+    private Integer id;
+    private String objectKey;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/ImageResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/ImageResponseDto.java
@@ -1,0 +1,14 @@
+package kakao_tech_bootcamp.community.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class ImageResponseDto {
+    private Integer id;
+    private String url; // presigned PUT URL과 CloudFront GET URL 자리
+    private String objectKey;
+    private String filename;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberCreateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberCreateRequestDto.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import kakao_tech_bootcamp.community.entity.Image;
 import lombok.Getter;
 
 @Getter
@@ -22,5 +21,5 @@ public class MemberCreateRequestDto {
     @Pattern(regexp = "^\\S{1,10}$", message = "닉네임 형식이 유효하지 않습니다")
     private String nickname;
 
-    private Image image;
+    private ImageReferenceDto image;
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberResponseDto.java
@@ -1,6 +1,5 @@
 package kakao_tech_bootcamp.community.dto;
 
-import kakao_tech_bootcamp.community.entity.Image;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,6 +12,6 @@ public class MemberResponseDto {
     private Integer id;
     private String email;
     private String nickname;
-    private Image image;
+    private ImageResponseDto image;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package kakao_tech_bootcamp.community.dto;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
@@ -14,4 +15,7 @@ public class MemberUpdateRequestDto {
     private String nickname;
 
     private ImageReferenceDto image;
+
+    @NotNull(message = "imageDeleted 필드는 필수 값입니다")
+    private Boolean imageDeleted;
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
@@ -1,7 +1,6 @@
 package kakao_tech_bootcamp.community.dto;
 
 import jakarta.validation.constraints.Pattern;
-import kakao_tech_bootcamp.community.entity.Image;
 import lombok.Getter;
 
 @Getter
@@ -14,5 +13,5 @@ public class MemberUpdateRequestDto {
     @Pattern(regexp = "^\\S{1,10}$", message = "닉네임 형식이 유효하지 않습니다")
     private String nickname;
 
-    private Image image;
+    private ImageReferenceDto image;
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/ImageRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/ImageRepository.java
@@ -1,0 +1,9 @@
+package kakao_tech_bootcamp.community.repository;
+
+import kakao_tech_bootcamp.community.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Integer> {
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/SessionRepository.java
@@ -3,7 +3,9 @@ package kakao_tech_bootcamp.community.repository;
 import kakao_tech_bootcamp.community.service.AuthInfo;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -20,7 +22,20 @@ public class SessionRepository {
         return Optional.ofNullable(sessions.get(sessionId));
     }
 
-    public void delete(String sessionId) {
+    public void deleteById(String sessionId) {
         sessions.remove(sessionId);
+    }
+
+    public void delete(AuthInfo authInfo) {
+        sessions.entrySet().stream()
+                .filter(entry -> Objects.equals(authInfo, entry.getValue()))
+                .findFirst()
+                .ifPresent(entry -> sessions.remove(entry.getKey()));
+    }
+
+    public List<AuthInfo> findAllByMemberId(Integer memberId) {
+        return sessions.values().stream()
+                .filter(authInfo -> Objects.equals(authInfo.getId(), memberId))
+                .toList();
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
@@ -10,10 +10,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
 public class AuthSessionStrategy implements AuthStrategy {
+    private final static int SESSION_LIMIT = 5;
+
     private final SessionRepository sessionRepository;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -38,6 +43,18 @@ public class AuthSessionStrategy implements AuthStrategy {
             throw new NotFoundException("회원을 찾을 수 없습니다");
         }
 
+        List<AuthInfo> memberSessions = sessionRepository.findAllByMemberId(member.getId());
+
+        /*
+         각 회원은 로그인 세션 최대 5개까지 유지 가능
+         이미 5개의 세션이 등록돼 있는데 새로 로그인 시도 시 가장 오래된 세션 정보 자동 삭제
+         */
+        if (memberSessions.size() >= SESSION_LIMIT) {
+            memberSessions.stream()
+                    .min(Comparator.comparing(AuthInfo::getCreatedAt))
+                    .ifPresent(sessionRepository::delete);
+        }
+
         String sessionId = UUID.randomUUID().toString();
         AuthInfo session = new AuthInfo(member.getId());
 
@@ -52,7 +69,7 @@ public class AuthSessionStrategy implements AuthStrategy {
                 .orElseThrow(() -> new NotFoundException("인증 정보를 찾을 수 없습니다"));
 
         if (session.isExpired()) {
-            sessionRepository.delete(credential);
+            sessionRepository.deleteById(credential);
             throw new UnauthorizedException("인증 정보가 만료됐습니다");
         }
 
@@ -62,6 +79,6 @@ public class AuthSessionStrategy implements AuthStrategy {
     @Override
     public void invalidate(String credential) {
         // 로그아웃하는 상황에 만약 sessionRepository에 삭제할 세션ID가 없더라도 404 에러를 낼 이유가 없음
-        sessionRepository.delete(credential);
+        sessionRepository.deleteById(credential);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
@@ -1,0 +1,108 @@
+package kakao_tech_bootcamp.community.service;
+
+import kakao_tech_bootcamp.community.common.exceptions.BadRequestException;
+import kakao_tech_bootcamp.community.dto.ImageResponseDto;
+import kakao_tech_bootcamp.community.entity.Image;
+import kakao_tech_bootcamp.community.entity.ImageStatus;
+import kakao_tech_bootcamp.community.repository.ImageRepository;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Log4j2
+@Service
+@Transactional
+public class ImageService {
+    @Value("${storage.domain}")
+    private String domain; // S3 사용한다고 가정해 dirPath 대신 domain 이름 설정
+    private final List<String> AVAILABLE_EXTENSIONS = List.of("png", "jpg", "jpeg", "png", "webp", "heic", "heif");
+    private final String REGEX = ".([a-zA-Z]+)$";
+
+    private final ImageRepository imageRepository;
+
+    @Autowired
+    public ImageService(ImageRepository imageRepository) {
+        this.imageRepository = imageRepository;
+    }
+
+    public ImageResponseDto saveImage(Integer currentMemberId, String type, MultipartFile file) throws IOException{
+        String filename = file.getOriginalFilename();
+
+        String objectKey = createObjectKey(currentMemberId, type, filename);
+        Image image = new Image(filename, objectKey, ImageStatus.PENDING);
+        Image saveImage = imageRepository.save(image);
+
+        String filepath = createUrl(objectKey);
+        File destination = new File(filepath);
+        destination.getParentFile().mkdirs();
+        file.transferTo(destination);
+
+        ImageResponseDto imageResponseDto = new ImageResponseDto();
+        imageResponseDto.setId(saveImage.getId());
+        imageResponseDto.setObjectKey(objectKey);
+        imageResponseDto.setFilename(filename);
+
+        return imageResponseDto;
+    }
+
+    private String createObjectKey(Integer currentMemberId, String type, String filename) {
+        Matcher matcher = Pattern.compile(REGEX).matcher(filename);
+
+        if (!matcher.find()) {
+            throw new BadRequestException("이미지 파일(png, jpg, jpeg, png, webp, heic, heif)만 업로드할 수 있습니다");
+        }
+
+        String extension = matcher.group(1);
+        validateExtension(extension);
+
+        StringBuffer sb = new StringBuffer();
+
+        if ("posts".equals(type)) {
+            LocalDate current = LocalDate.now();
+            sb.append("posts/")
+                    .append(current.getYear())
+                    .append("/")
+                    .append(current.getMonthValue())
+                    .append("/")
+                    .append(UUID.randomUUID().toString())
+                    .append(".")
+                    .append(extension);
+
+            return sb.toString();
+        }
+
+        if ("members".equals(type)) {
+            sb.append("members/")
+                    .append(currentMemberId)
+                    .append("/")
+                    .append(UUID.randomUUID().toString())
+                    .append(".")
+                    .append(extension);
+
+            return sb.toString();
+        }
+
+        throw new BadRequestException("잘못된 요청입니다");
+    }
+
+    private void validateExtension(String extension) {
+        if (!AVAILABLE_EXTENSIONS.contains(extension)) {
+            throw new BadRequestException("이미지 파일(png, jpg, jpeg, png, webp, heic, heif)만 업로드할 수 있습니다");
+        }
+    }
+
+    private String createUrl(String objectKey) {
+        return domain + objectKey;
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
@@ -1,6 +1,7 @@
 package kakao_tech_bootcamp.community.service;
 
 import kakao_tech_bootcamp.community.common.exceptions.BadRequestException;
+import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
 import kakao_tech_bootcamp.community.dto.ImageResponseDto;
 import kakao_tech_bootcamp.community.entity.Image;
 import kakao_tech_bootcamp.community.entity.ImageStatus;
@@ -54,6 +55,22 @@ public class ImageService {
         return imageResponseDto;
     }
 
+    public Image modifyImageStatusById(Integer imageId, ImageStatus imageStatus) {
+        Image image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new NotFoundException("이미지를 찾을 수 없습니다"));
+        image.setStatus(imageStatus);
+        // TODO: 엔티티 말고 dto를 반환할 방법?
+        return image;
+    }
+
+    public void removeImage(Integer imageId, String objectKey) {
+        imageRepository.deleteById(imageId);
+
+        String filepath = createUrl(objectKey);
+        File destination = new File(filepath);
+        destination.delete(); // 물리적 이미지 파일 없거나 삭제 실패해도 오류 X
+    }
+
     private String createObjectKey(String type, String filename) {
         Matcher matcher = Pattern.compile(REGEX).matcher(filename);
 
@@ -98,7 +115,7 @@ public class ImageService {
         }
     }
 
-    private String createUrl(String objectKey) {
+    public String createUrl(String objectKey) {
         return domain + objectKey;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
@@ -5,7 +5,6 @@ import kakao_tech_bootcamp.community.dto.ImageResponseDto;
 import kakao_tech_bootcamp.community.entity.Image;
 import kakao_tech_bootcamp.community.entity.ImageStatus;
 import kakao_tech_bootcamp.community.repository.ImageRepository;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,6 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@Log4j2
 @Service
 @Transactional
 public class ImageService {
@@ -36,10 +34,10 @@ public class ImageService {
         this.imageRepository = imageRepository;
     }
 
-    public ImageResponseDto saveImage(Integer currentMemberId, String type, MultipartFile file) throws IOException{
+    public ImageResponseDto saveImage(String type, MultipartFile file) throws IOException{
         String filename = file.getOriginalFilename();
 
-        String objectKey = createObjectKey(currentMemberId, type, filename);
+        String objectKey = createObjectKey(type, filename);
         Image image = new Image(filename, objectKey, ImageStatus.PENDING);
         Image saveImage = imageRepository.save(image);
 
@@ -56,7 +54,7 @@ public class ImageService {
         return imageResponseDto;
     }
 
-    private String createObjectKey(Integer currentMemberId, String type, String filename) {
+    private String createObjectKey(String type, String filename) {
         Matcher matcher = Pattern.compile(REGEX).matcher(filename);
 
         if (!matcher.find()) {
@@ -84,8 +82,6 @@ public class ImageService {
 
         if ("members".equals(type)) {
             sb.append("members/")
-                    .append(currentMemberId)
-                    .append("/")
                     .append(UUID.randomUUID().toString())
                     .append(".")
                     .append(extension);

--- a/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
@@ -23,11 +23,11 @@ import java.util.regex.Pattern;
 @Service
 @Transactional
 public class ImageService {
+    private final static List<String> AVAILABLE_EXTENSIONS = List.of("png", "jpg", "jpeg", "png", "webp", "heic", "heif");
+    private final static String REGEX = ".([a-zA-Z]+)$";
+
     @Value("${storage.domain}")
     private String domain; // S3 사용한다고 가정해 dirPath 대신 domain 이름 설정
-    private final List<String> AVAILABLE_EXTENSIONS = List.of("png", "jpg", "jpeg", "png", "webp", "heic", "heif");
-    private final String REGEX = ".([a-zA-Z]+)$";
-
     private final ImageRepository imageRepository;
 
     @Autowired

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -117,7 +117,14 @@ public class MemberService {
             Image currentImage = imageService.modifyImageStatusById(dto.getImage().getId(), ImageStatus.ACTIVE);
             member.setImage(currentImage);
 
-            imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
+            /*
+             removeImage()에는 데이터베이스뿐만 아니라 물리적인 이미지 파일 삭제까지 포함되어 있음
+             물리적인 이미지 파일 삭제는 트랜잭션처럼 롤백되지 못하므로
+             모든 데이터베이스 작업이 정상적으로 완료되어 이미지 삭제가 확정된 가장 마지막 시점에 이미지 삭제 처리 진행
+             */
+            if (previousImage != null) {
+                imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
+            }
         }
     }
 

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -4,10 +4,9 @@ import kakao_tech_bootcamp.community.common.exceptions.BadRequestException;
 import kakao_tech_bootcamp.community.common.exceptions.ConflictException;
 import kakao_tech_bootcamp.community.common.exceptions.ForbiddenException;
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
-import kakao_tech_bootcamp.community.dto.MemberAvailabilityDto;
-import kakao_tech_bootcamp.community.dto.MemberCreateRequestDto;
-import kakao_tech_bootcamp.community.dto.MemberResponseDto;
-import kakao_tech_bootcamp.community.dto.MemberUpdateRequestDto;
+import kakao_tech_bootcamp.community.dto.*;
+import kakao_tech_bootcamp.community.entity.Image;
+import kakao_tech_bootcamp.community.entity.ImageStatus;
 import kakao_tech_bootcamp.community.entity.Member;
 import kakao_tech_bootcamp.community.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,15 +14,19 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
 @Transactional
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final ImageService imageService;
     private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+    public MemberService(MemberRepository memberRepository, ImageService imageService, PasswordEncoder passwordEncoder) {
         this.memberRepository = memberRepository;
+        this.imageService = imageService;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -54,8 +57,12 @@ public class MemberService {
             throw new ConflictException("중복된 닉네임입니다");
         }
 
+        Image image = dto.getImage() != null
+                ? imageService.modifyImageStatusById(dto.getImage().getId(), ImageStatus.ACTIVE)
+                : null;
+
         String encoded = passwordEncoder.encode(dto.getPassword());
-        Member member = new Member(dto.getEmail(), encoded, dto.getNickname(), dto.getImage());
+        Member member = new Member(dto.getEmail(), encoded, dto.getNickname(), image);
 
         memberRepository.save(member);
     }
@@ -65,17 +72,25 @@ public class MemberService {
         Member member = memberRepository.findById(id).orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
         MemberResponseDto memberResponseDto = new MemberResponseDto();
+        ImageResponseDto imageResponseDto = new ImageResponseDto();
+        Image image = member.getImage();
+
+        imageResponseDto.setId(image.getId());
+        imageResponseDto.setUrl(imageService.createUrl(image.getObjectKey()));
+        imageResponseDto.setObjectKey(image.getObjectKey());
+        imageResponseDto.setFilename(image.getFilename());
+
         memberResponseDto.setId(member.getId());
         memberResponseDto.setEmail(member.getEmail());
         memberResponseDto.setNickname(member.getNickname());
-        memberResponseDto.setImage(member.getImage());
+        memberResponseDto.setImage(imageResponseDto);
         memberResponseDto.setCreatedAt(member.getCreatedAt());
 
         return memberResponseDto;
     }
 
     public void modifyMember(Integer currentMemberId, Integer id, MemberUpdateRequestDto dto) {
-        if (currentMemberId != id) {
+        if (!Objects.equals(currentMemberId, id)) {
             throw new ForbiddenException("회원 본인 정보에 대해서만 수정할 수 있습니다");
         }
 
@@ -95,17 +110,27 @@ public class MemberService {
         }
 
         if (dto.getImage() != null) {
-            member.setImage(dto.getImage());
+            Image previousImage = member.getImage();
+
+            Image currentImage = imageService.modifyImageStatusById(dto.getImage().getId(), ImageStatus.ACTIVE);
+            member.setImage(currentImage);
+
+            imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
         }
     }
 
     public void removeMember(Integer currentMemberId, Integer id) {
-        if (currentMemberId != id) {
+        if (!Objects.equals(currentMemberId, id)) {
             throw new ForbiddenException("회원 본인만 탈퇴할 수 있습니다");
         }
 
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
-        memberRepository.delete(member);
+
+        memberRepository.delete(member); // image on delete cascade
+
+        if (member.getImage() != null) {
+            imageService.removeImage(member.getImage().getId(), member.getImage().getObjectKey());
+        }
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -73,17 +73,19 @@ public class MemberService {
 
         MemberResponseDto memberResponseDto = new MemberResponseDto();
         ImageResponseDto imageResponseDto = new ImageResponseDto();
-        Image image = member.getImage();
 
-        imageResponseDto.setId(image.getId());
-        imageResponseDto.setUrl(imageService.createUrl(image.getObjectKey()));
-        imageResponseDto.setObjectKey(image.getObjectKey());
-        imageResponseDto.setFilename(image.getFilename());
+        if (member.getImage() != null) {
+            Image image = member.getImage();
+            imageResponseDto.setId(image.getId());
+            imageResponseDto.setUrl(imageService.createUrl(image.getObjectKey()));
+            imageResponseDto.setObjectKey(image.getObjectKey());
+            imageResponseDto.setFilename(image.getFilename());
+            memberResponseDto.setImage(imageResponseDto);
+        }
 
         memberResponseDto.setId(member.getId());
         memberResponseDto.setEmail(member.getEmail());
         memberResponseDto.setNickname(member.getNickname());
-        memberResponseDto.setImage(imageResponseDto);
         memberResponseDto.setCreatedAt(member.getCreatedAt());
 
         return memberResponseDto;

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -111,6 +111,17 @@ public class MemberService {
             member.setPassword(passwordEncoder.encode(dto.getPassword()));
         }
 
+        /*
+          dto.getImageDeleted() → 기존 프로필 이미지 제거할 때만 처리 (기존 프로필 이미지 유지 및 다른 이미지로 변경과는 무관)
+          dto.getImage() == null → 단, imageDeleted == true더라도 새 이미지 전달하면(not null) 프로필 이미지 변경으로 간주
+          member.getImage() != null → 기존 프로필 있을 때만 제거 처리
+         */
+        if (dto.getImageDeleted() && dto.getImage() == null && member.getImage() != null) {
+            Image previousImage = member.getImage();
+            member.setImage(null);
+            imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
+        }
+
         if (dto.getImage() != null) {
             Image previousImage = member.getImage();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,10 @@ spring:
       hibernate:
         format_sql: true
 
+  multipart:
+    max-file-size: 10MB
+    max-request-size: 10MB
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 작업 내용

- 애플리케이션 내 폴더에 이미지를 업로드했지만, 추후 S3 도입을 고려해 최대한 S3 로직에 맞춰 코드 작성
    > Multipart 사용 시 회원/게시글 정보와 함께 회원/게시글 생성 때 함께 보내는 게 더 깔끔하다고 보지만, S3 로직에 맞춤 
    - S3 presigned PUT URL 요청하는 GET API ➡️ Mutlipart로 이미지 업로드하는 POST API
    - objectKey ➡️ 프로젝트 내 이미지 경로 의미
    - (CloudFront) url ➡️ 프로젝트 디렉터리 경로 + 프로젝트 내 이미지 경로 의미

- Image 관련 DTO 생성
    - 기존 Member DTO들에서 사용하던 Image를 Image DTO로 교체

- 이미지 저장 및 상태 변경, 삭제 로직 담은 ImageService 작성

- MemberService에서도 프로필 이미지 관련 로직 추가
    - 게시글 생성
        - 게시글 이미지 업로드 → pending → 게시글 작성 → active
        - 게시글 이미지 업로드 → pending → 게시글 작성 취소 → pending (매일 자정 삭제)
    - 이미지 첨부된 기존 게시글 수정
        - 새 이미지 업로드 → 새 이미지 pending → 게시글 수정 요청 → 새 이미지 active , 기존 이미지 삭제
        - 새 이미지 업로드 → 새 이미지 pending → 게시글 수정 취소 → 새 이미지 pending (매일 자정 삭제) , 기존 이미지 유지

<br>
<br>
<br>

## 고민 내용

### 로그인한 사람이 또 로그인 시도하는 상황
- 초기 아이디어
    - 버그라고 판단 → 로그인한 상태로 다시 로그인 시도하면 해당 요청 거부 or 세션 갱신 계획
- 그러나 여러 기기에서 로그인하고 그 상태를 유지한다면 한 회원에 대해 여러 세션 정보 존재 가능
- `결론` 따라서 로그인한 회원이 또 로그인 시 새로운 세션 추가 생성하도록 함
    - 단, 최대 5개까지 세션 생성 가능
    - 5개 세션 있는데 추가로 로그인하면 가장 오래된 세션 자동 삭제 후 새 세션 생성

<br>

### MemberService에 ImageService 주입받아도 되는가?
- ImageService는 데이터베이스와 물리적 이미지 파일 둘 다 관리
- MemberService에서 프로필 사진 관련 로직 처리 시
    - 데이터베이스 다루는 ImageRepository만으로 안 되고
    - 이미지 파일까지 다루는 ImageService 기능 필요
- `결론` MemberService가 ImageService 주입 받는 구조 사용
    - MemberService에서 ImageRepository만 주입받으면 결국 **ImageService의 이미지 파일 처리 로직을 MemberService에 중복 작성**하게 됨
    - 또한 MemberService만 ImageService 참조할 뿐, ImageService는 MemberService를 참조하지 않음
        - 즉, 순환참조가 아님
    > ImageService가 하는 2가지 역할을 두 가지 클래스로 분리하는 방법도 고민해 봤지만
    > 결국엔 ImageDatabaseService, ImageFileService로 나뉠 뿐 명쾌한 해답은 아니라고 판단

<br>

### 기존에 존재하던 회원 프로필 사진 삭제만 한다면 어떻게 알아채지?
- 문제 상황
    - 회원 수정 API에 PATCH 메서드 사용 → MemberUpdateRequestDto에 정의된 필드 값이 null이면 변경 X
    - 그럼 프로필을 다른 사진으로 변경하는 게 아니라, 기존 프로필만 삭제하는 거라면? → image 필드 값 null → 프로필 이미지 변경사항 없다고 파악 → 기존 프로필 이미지 유지
- 해결 아이디어
    1. DTO에 이미지 삭제 여부 나타내는 `imageDeleted` 필수 필드 추가
        - 프로필 이미지 변경 및 유지할 땐 `imageDeleted: false`
        - 오직 프로필 이미지를 없앨 때만 `imageDeleted: true`
    2. 프로필 이미지 삭제 API 별도 정의
        - REST API 관점에서 가장 원칙적인 방식
        - 그러나 예를 들어 회원 정보 수정 페이지에서 회원 닉네임 변경과 프로필 이미지 제거 후 `수정 완료` 버튼 클릭 시
            - 닉네임 변경으로 `PATCH /members/{memberId}` 호출
            - 프로필 이미지 제거로 `DELETE /images/{imageId}` 호출
            - 2개의 요청을 날려야 함
        - 회원 닉네임 변경과 프로필 이미지 수정 시엔
            - `PATCH /members/{memberId}` 호출하고
        - REST 원칙을 지키려다 API 스펙이 복잡해짐
- `결론` 회원 수정 요청 DTO에 `imageDeleted` 필수 필드 추가

<br>
<br>
<br>

## 화면 캡처
- 이미지 업로드
    <img width="670" height="480" alt="image" src="https://github.com/user-attachments/assets/896e8d57-6a27-4925-9d70-d78431dbf679" />

- 회원 프로필 이미지 수정
    <img width="3598" height="700" alt="image" src="https://github.com/user-attachments/assets/8e81bc81-e194-401d-b1fd-f1e58c54ac6e" />

- 회원 프로필 제거
    <img width="1868" height="511" alt="image" src="https://github.com/user-attachments/assets/3705090b-2bf8-423a-afb5-88deb545dbe3" />
