### PR TITLE
[feat] 게시글 API 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,16 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-security"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean {
+    delete file('src/main/generated')
 }

--- a/src/main/java/kakao_tech_bootcamp/community/config/QuerydslConfig.java
+++ b/src/main/java/kakao_tech_bootcamp/community/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package kakao_tech_bootcamp.community.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -1,0 +1,25 @@
+package kakao_tech_bootcamp.community.controller;
+
+import kakao_tech_bootcamp.community.common.ApiResponse;
+import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
+import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
+import kakao_tech_bootcamp.community.service.AuthInfo;
+import kakao_tech_bootcamp.community.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> savePost(@CurrentMember AuthInfo authInfo,
+                                                @RequestBody PostCreateRequestDto postCreateRequestDto) {
+        postService.savePost(authInfo.getId(), postCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("post_create_success", null));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -49,5 +50,15 @@ public class PostController {
                                                   @RequestBody @Validated PostUpdateRequestDto postUpdateRequestDto) {
         postService.modifyPost(authInfo.getId(), postId, postUpdateRequestDto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse> removePosts(@CurrentMember AuthInfo authInfo,
+                                      @RequestParam(value = "before", required = false) LocalDate before,
+                                      @RequestParam(value = "after", required = false) LocalDate after,
+                                      @RequestParam(value = "writer", required = false) Integer memberId) {
+        // TODO: 회원 권한 확인 필요
+        long affectedRows = postService.removePosts(before, after, memberId);
+        return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("affectedRows", affectedRows)));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -3,12 +3,15 @@ package kakao_tech_bootcamp.community.controller;
 import kakao_tech_bootcamp.community.common.ApiResponse;
 import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
 import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
+import kakao_tech_bootcamp.community.dto.PostResponseDto;
 import kakao_tech_bootcamp.community.service.AuthInfo;
 import kakao_tech_bootcamp.community.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/posts")
@@ -21,5 +24,12 @@ public class PostController {
                                                 @RequestBody PostCreateRequestDto postCreateRequestDto) {
         postService.savePost(authInfo.getId(), postCreateRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("post_create_success", null));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse> findPost(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
+        PostResponseDto post = postService.findPost(authInfo.getId(), postId);
+        Map<String, PostResponseDto> data = Map.of("post", post);
+        return ResponseEntity.ok(new ApiResponse<>("ok", data));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -4,11 +4,13 @@ import kakao_tech_bootcamp.community.common.ApiResponse;
 import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
 import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
 import kakao_tech_bootcamp.community.dto.PostResponseDto;
+import kakao_tech_bootcamp.community.dto.PostUpdateRequestDto;
 import kakao_tech_bootcamp.community.service.AuthInfo;
 import kakao_tech_bootcamp.community.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -39,5 +41,13 @@ public class PostController {
     public ResponseEntity<ApiResponse> findPost(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
         PostResponseDto post = postService.findPost(authInfo.getId(), postId);
         return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("post", post)));
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity modifyPost(@CurrentMember AuthInfo authInfo,
+                                                  @PathVariable Integer postId,
+                                                  @RequestBody @Validated PostUpdateRequestDto postUpdateRequestDto) {
+        postService.modifyPost(authInfo.getId(), postId, postUpdateRequestDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -26,10 +27,17 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("post_create_success", null));
     }
 
+    @GetMapping
+    public ResponseEntity<ApiResponse> findPosts(@CurrentMember AuthInfo authInfo,
+                                                 @RequestParam(value = "lastPostId", required = false) Integer lastPostId,
+                                                 @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+        List<PostResponseDto> posts = postService.findPosts(authInfo.getId(), lastPostId, limit);
+        return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("posts", posts)));
+    }
+
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse> findPost(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
         PostResponseDto post = postService.findPost(authInfo.getId(), postId);
-        Map<String, PostResponseDto> data = Map.of("post", post);
-        return ResponseEntity.ok(new ApiResponse<>("ok", data));
+        return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("post", post)));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
@@ -1,12 +1,18 @@
 package kakao_tech_bootcamp.community.dto;
 
+import kakao_tech_bootcamp.community.entity.Image;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter @Setter
+@Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ImageReferenceDto {
     private Integer id;
     private String objectKey;
+
+    public static ImageReferenceDto of(Image image) {
+        return image != null ? new ImageReferenceDto(image.getId(), image.getObjectKey()) : new ImageReferenceDto();
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
@@ -1,0 +1,16 @@
+package kakao_tech_bootcamp.community.dto;
+
+import kakao_tech_bootcamp.community.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberReferenceDto {
+    private String nickname;
+    private ImageReferenceDto image;
+
+    public static MemberReferenceDto of(Member member) {
+        return new MemberReferenceDto(member.getNickname(), ImageReferenceDto.of(member.getImage()));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberResponseDto.java
@@ -1,17 +1,22 @@
 package kakao_tech_bootcamp.community.dto;
 
+import kakao_tech_bootcamp.community.entity.Member;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Getter @Setter
-@NoArgsConstructor
+@Getter
+@AllArgsConstructor
 public class MemberResponseDto {
     private Integer id;
     private String email;
     private String nickname;
-    private ImageResponseDto image;
+    private ImageReferenceDto image;
     private LocalDateTime createdAt;
+
+    public static MemberResponseDto of(Member member) {
+        return new MemberResponseDto(member.getId(), member.getEmail(),
+                member.getNickname(),ImageReferenceDto.of(member.getImage()), member.getCreatedAt());
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/PostCreateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/PostCreateRequestDto.java
@@ -1,0 +1,18 @@
+package kakao_tech_bootcamp.community.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class PostCreateRequestDto {
+    @NotBlank(message = "제목 형식이 유효하지 않습니다")
+    @Size(max = 26, message = "제목 형식이 유효하지 않습니다")
+    private String title;
+
+    @NotBlank(message = "내용이 존재하지 않습니다")
+    @Size(min = 1, message = "내용이 존재하지 않습니다")
+    private String content;
+
+    private ImageReferenceDto image;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/PostResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/PostResponseDto.java
@@ -16,16 +16,16 @@ public class PostResponseDto {
     private MemberReferenceDto member;
     private ImageReferenceDto image;
     private LocalDateTime createdAt;
-//    private boolean isLiked;
+    private boolean isLiked;
     private int viewCount;
     private int likeCount;
     private int commentCount;
 
-    public static PostResponseDto of(Post post, PostStat postStat) {
+    public static PostResponseDto of(Post post, boolean isLiked, PostStat postStat) {
         return new PostResponseDto(post.getId(), post.getTitle(), post.getContent(),
                 MemberReferenceDto.of(post.getMember()),
                 ImageReferenceDto.of(post.getImage()),
-                post.getCreatedAt(),
+                post.getCreatedAt(), isLiked,
                 postStat.getViewCount(), postStat.getLikeCount(), postStat.getCommentCount());
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/PostResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/PostResponseDto.java
@@ -1,0 +1,31 @@
+package kakao_tech_bootcamp.community.dto;
+
+import kakao_tech_bootcamp.community.entity.Post;
+import kakao_tech_bootcamp.community.entity.PostStat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostResponseDto {
+    private Integer id;
+    private String title;
+    private String content;
+    private MemberReferenceDto member;
+    private ImageReferenceDto image;
+    private LocalDateTime createdAt;
+//    private boolean isLiked;
+    private int viewCount;
+    private int likeCount;
+    private int commentCount;
+
+    public static PostResponseDto of(Post post, PostStat postStat) {
+        return new PostResponseDto(post.getId(), post.getTitle(), post.getContent(),
+                MemberReferenceDto.of(post.getMember()),
+                ImageReferenceDto.of(post.getImage()),
+                post.getCreatedAt(),
+                postStat.getViewCount(), postStat.getLikeCount(), postStat.getCommentCount());
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/PostUpdateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/PostUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package kakao_tech_bootcamp.community.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class PostUpdateRequestDto {
+    @Size(max = 26, message = "제목 형식이 유효하지 않습니다")
+    private String title;
+
+    @Size(min = 1, message = "내용이 존재하지 않습니다")
+    private String content;
+
+    private ImageReferenceDto image;
+
+    @NotNull(message = "imageDeleted 필드는 필수 값입니다")
+    private Boolean imageDeleted;
+
+    @NotNull(message = "postDeleted 필드는 필수 값입니다")
+    private Boolean postDeleted;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Comment.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Comment.java
@@ -21,11 +21,11 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Member.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Member.java
@@ -30,7 +30,7 @@ public class Member {
     @Column(length = 10, nullable = false, unique = true)
     private String nickname;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
     private Image image;
 

--- a/src/main/java/kakao_tech_bootcamp/community/entity/MemberPostLikeId.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/MemberPostLikeId.java
@@ -2,19 +2,15 @@ package kakao_tech_bootcamp.community.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Embeddable
-@Getter @Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MemberPostLikeId {
     @Column(name = "post_id", nullable = false, updatable = false)
     private Integer postId;
     @Column(name = "member_id", nullable = false, updatable = false)
     private Integer memberId;
-
-    public MemberPostLikeId(Integer postId, Integer memberId) {
-        this.postId = postId;
-        this.memberId = memberId;
-    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/entity/MemberPostLikeId.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/MemberPostLikeId.java
@@ -1,5 +1,6 @@
 package kakao_tech_bootcamp.community.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,7 +8,9 @@ import lombok.Setter;
 @Embeddable
 @Getter @Setter
 public class MemberPostLikeId {
+    @Column(name = "post_id", nullable = false, updatable = false)
     private Integer postId;
+    @Column(name = "member_id", nullable = false, updatable = false)
     private Integer memberId;
 
     public MemberPostLikeId(Integer postId, Integer memberId) {

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Post.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Post.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "post")
 @Getter @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class Post {
     @Id
@@ -27,11 +27,11 @@ public class Post {
     @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
     private Image image;
 

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Post.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Post.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,9 +11,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "post")
-@Getter @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class Post {
     @Id
@@ -43,9 +42,26 @@ public class Post {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public Post(String title, String content, Member member) {
+    public Post(String title, String content, Member member, Image image) {
         this.title = title;
         this.content = content;
         this.member = member;
+        this.image = image;
+    }
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
+
+    public void changeImage(Image image) {
+        this.image = image;
+    }
+
+    public void markDeleted() {
+        isDeleted = true;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/entity/PostAdditional.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/PostAdditional.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class PostAdditional {
     @Id
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/kakao_tech_bootcamp/community/entity/PostAdditional.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/PostAdditional.java
@@ -4,20 +4,22 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-
 @Entity
+@Getter
 @Table(name = "post_additional")
-@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class PostAdditional {
     @Id
+    @Column(name = "post_id")
+    private Integer id;
+
+    @MapsId
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
@@ -32,4 +34,16 @@ public class PostAdditional {
     @Column(name = "updated_at", nullable = false)
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public PostAdditional(Post post) {
+        this.post = post;
+    }
+
+    public void changeViewCount(int viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    private void markDeletedAt() {
+        deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/entity/PostStat.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/PostStat.java
@@ -1,0 +1,45 @@
+package kakao_tech_bootcamp.community.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor // 새 게시글 생성 시 인메모리DB에 올릴 때 사용
+@AllArgsConstructor // RDB에서 count하고 인메모리DB에 올릴 때 사용
+public class PostStat {
+    private final Integer postId;
+    private int viewCount;
+    private int likeCount;
+    private int commentCount;
+
+    public void incrementViewCount() {
+        viewCount++;
+    }
+
+    public void incrementLikeCount() {
+        likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        likeCount--;
+    }
+
+    public void incrementCommentCount() {
+        commentCount++;
+    }
+
+    public void decrementCommentCount() {
+        commentCount--;
+    }
+
+    // member_post_like 테이블 count 후 인메모리DB의 통계값 수정용 메서드
+    public void changeLikeCount(int likeCount) {
+        this.likeCount = likeCount;
+    }
+
+    // comment 테이블 count 후 인메모리DB의 통계값 수정용 메서드
+    public void changeCommentCount(int commentCount) {
+        this.commentCount = commentCount;
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/CommentRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/CommentRepository.java
@@ -1,10 +1,10 @@
 package kakao_tech_bootcamp.community.repository;
 
-import kakao_tech_bootcamp.community.entity.PostAdditional;
+import kakao_tech_bootcamp.community.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostAdditionalRepository extends JpaRepository<PostAdditional, Integer> {
+public interface CommentRepository extends JpaRepository<Comment, Integer> {
     int countByPostId(Integer postId);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/MemberPostLikeRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/MemberPostLikeRepository.java
@@ -1,0 +1,11 @@
+package kakao_tech_bootcamp.community.repository;
+
+import kakao_tech_bootcamp.community.entity.MemberPostLike;
+import kakao_tech_bootcamp.community.entity.MemberPostLikeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberPostLikeRepository extends JpaRepository<MemberPostLike, MemberPostLikeId> {
+    boolean existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(Integer postId, Integer memberId);
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/MemberPostLikeRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/MemberPostLikeRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberPostLikeRepository extends JpaRepository<MemberPostLike, MemberPostLikeId> {
     boolean existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(Integer postId, Integer memberId);
+
+    int countByMemberPostLikeIdPostId(Integer postId);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostAdditionalRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostAdditionalRepository.java
@@ -1,0 +1,9 @@
+package kakao_tech_bootcamp.community.repository;
+
+import kakao_tech_bootcamp.community.entity.PostAdditional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostAdditionalRepository extends JpaRepository<PostAdditional, Integer> {
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
@@ -4,6 +4,9 @@ import kakao_tech_bootcamp.community.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Integer> {
+    Optional<Post> findByIdAndIsDeletedFalse(Integer postId);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package kakao_tech_bootcamp.community.repository;
+
+import kakao_tech_bootcamp.community.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Integer> {
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Integer> {
+public interface PostRepository extends JpaRepository<Post, Integer>, PostRepositoryCustom {
     Optional<Post> findByIdAndIsDeletedFalse(Integer postId);
 
     // TODO: 카디널리티 폭발... 해결 필요

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
@@ -1,12 +1,22 @@
 package kakao_tech_bootcamp.community.repository;
 
 import kakao_tech_bootcamp.community.entity.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Integer> {
     Optional<Post> findByIdAndIsDeletedFalse(Integer postId);
+
+    // TODO: 카디널리티 폭발... 해결 필요
+    @EntityGraph(attributePaths = {"member", "member.image", "image"})
+    List<Post> findByIsDeletedFalseOrderByIdDesc(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "member.image", "image"})
+    List<Post> findByIsDeletedFalseAndIdLessThanOrderByIdDesc(Integer lastPostId, Pageable pageable);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustom.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustom.java
@@ -1,0 +1,7 @@
+package kakao_tech_bootcamp.community.repository;
+
+import java.time.LocalDateTime;
+
+public interface PostRepositoryCustom {
+    long deleteAllByIsDeletedTrueAndDynamicFilters(Integer memberId, LocalDateTime before, LocalDateTime after);
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package kakao_tech_bootcamp.community.repository;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static kakao_tech_bootcamp.community.entity.QPost.post;
+
+@RequiredArgsConstructor
+public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public long deleteAllByIsDeletedTrueAndDynamicFilters(Integer memberId, LocalDateTime before, LocalDateTime after) {
+        return jpaQueryFactory.delete(post)
+                .where(
+                        post.isDeleted.isTrue(),
+                        memberIdEq(memberId),
+                        createdAtBetween(before, after)
+                )
+                .execute();
+    }
+
+    private Predicate createdAtBetween(LocalDateTime before, LocalDateTime after) {
+        if (before != null && after != null) {
+            return post.createdAt.between(after, before);
+        }
+
+        if (before != null) {
+            return post.createdAt.before(before);
+        }
+
+        if (after != null) {
+            return post.createdAt.after(after);
+        }
+
+        return null;
+    }
+
+    private Predicate memberIdEq(Integer memberId) {
+        return memberId != null ? post.member.id.eq(memberId) : null;
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostStatRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostStatRepository.java
@@ -1,0 +1,56 @@
+package kakao_tech_bootcamp.community.repository;
+
+import kakao_tech_bootcamp.community.entity.PostStat;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class PostStatRepository {
+    /*
+     게시글 관련 통계 데이터(조회수, 좋아요수, 댓글수)를 관리하는 Redis 등의 캐시용 인메모리 DB
+     */
+    private Map<Integer, PostStat> store = new ConcurrentHashMap<>();
+
+    public void save(PostStat postStat) {
+        store.put(postStat.getPostId(), postStat);
+    }
+
+    public Optional<PostStat> findById(Integer postId) {
+        return Optional.ofNullable(store.get(postId));
+    }
+
+    public void incrementViewCount(Integer postId) {
+        Optional.ofNullable(store.get(postId)).ifPresent(PostStat::incrementViewCount);
+    }
+
+    public void incrementLikeCount(Integer postId) {
+        Optional.ofNullable(store.get(postId)).ifPresent(PostStat::incrementLikeCount);
+    }
+
+    public void decrementLikeCount(Integer postId) {
+        Optional.ofNullable(store.get(postId)).ifPresent(PostStat::decrementLikeCount);
+    }
+
+    public void incrementCommentCount(Integer postId) {
+        Optional.ofNullable(store.get(postId)).ifPresent(PostStat::incrementCommentCount);
+    }
+
+    public void decrementCommentCount(Integer postId) {
+        Optional.ofNullable(store.get(postId)).ifPresent(PostStat::decrementCommentCount);
+    }
+
+    public void updateLikeCount(Integer postId, int likeCount) {
+        Optional.ofNullable(store.get(postId)).ifPresent(x -> x.changeLikeCount(likeCount));
+    }
+
+    public void updateCommentCount(Integer postId, int commentCount) {
+        Optional.ofNullable(store.get(postId)).ifPresent(x -> x.changeCommentCount(commentCount));
+    }
+
+    public void deleteById(Integer postId) {
+        store.remove(postId);
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -70,25 +70,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberResponseDto findMember(Integer id) {
         Member member = memberRepository.findById(id).orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
-
-        MemberResponseDto memberResponseDto = new MemberResponseDto();
-        ImageResponseDto imageResponseDto = new ImageResponseDto();
-
-        if (member.getImage() != null) {
-            Image image = member.getImage();
-            imageResponseDto.setId(image.getId());
-            imageResponseDto.setUrl(imageService.createUrl(image.getObjectKey()));
-            imageResponseDto.setObjectKey(image.getObjectKey());
-            imageResponseDto.setFilename(image.getFilename());
-            memberResponseDto.setImage(imageResponseDto);
-        }
-
-        memberResponseDto.setId(member.getId());
-        memberResponseDto.setEmail(member.getEmail());
-        memberResponseDto.setNickname(member.getNickname());
-        memberResponseDto.setCreatedAt(member.getCreatedAt());
-
-        return memberResponseDto;
+        return MemberResponseDto.of(member);
     }
 
     public void modifyMember(Integer currentMemberId, Integer id, MemberUpdateRequestDto dto) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -17,6 +17,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostAdditionalRepository postAdditionalRepository;
     private final PostStatRepository postStatRepository;
+    private final MemberPostLikeRepository memberPostLikeRepository;
     private final MemberRepository memberRepository;
     private final ImageRepository imageRepository;
 
@@ -38,13 +39,13 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
 
-        PostStat postStat = postStatRepository.findById(postId)
-                .orElseGet(() -> findPostStat(postId));
+        PostStat postStat = postStatRepository.findById(postId).orElseGet(() -> findPostStat(postId));
+        boolean isLiked = memberPostLikeRepository.existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(postId, currentMemberId);
 
         postStat.incrementViewCount();
         postStatRepository.save(postStat);
 
-        return PostResponseDto.of(post, postStat);
+        return PostResponseDto.of(post, isLiked, postStat);
     }
 
     private void savePost(Post post) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -2,6 +2,7 @@ package kakao_tech_bootcamp.community.service;
 
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
 import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
+import kakao_tech_bootcamp.community.dto.PostResponseDto;
 import kakao_tech_bootcamp.community.entity.*;
 import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +34,30 @@ public class PostService {
         savePost(new Post(dto.getTitle(), dto.getContent(), member, image));
     }
 
+    public PostResponseDto findPost(Integer currentMemberId, Integer postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
+
+        PostStat postStat = postStatRepository.findById(postId)
+                .orElseGet(() -> findPostStat(postId));
+
+        postStat.incrementViewCount();
+        postStatRepository.save(postStat);
+
+        return PostResponseDto.of(post, postStat);
+    }
+
     private void savePost(Post post) {
         Post savePost = postRepository.save(post);
         postAdditionalRepository.save(new PostAdditional(savePost));
         postStatRepository.save(new PostStat(savePost.getId()));
+    }
+
+    private PostStat findPostStat(Integer postId) {
+        // TODO: PostAdditional, MemberPostLike, Comment 레포지터리에서 count 조회 후 초기화
+        int viewCount = 0;
+        int likeCount = 0;
+        int commentCount = 0;
+        return new PostStat(postId, viewCount, likeCount, commentCount);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -20,6 +20,7 @@ public class PostService {
     private final MemberPostLikeRepository memberPostLikeRepository;
     private final MemberRepository memberRepository;
     private final ImageRepository imageRepository;
+    private final CommentRepository commentRepository;
 
     public void savePost(Integer currentMemberId, PostCreateRequestDto dto) {
         Member member = memberRepository.findById(currentMemberId)
@@ -56,10 +57,9 @@ public class PostService {
     }
 
     private PostStat findPostStat(Integer postId) {
-        // TODO: PostAdditional, MemberPostLike, Comment 레포지터리에서 count 조회 후 초기화
-        int viewCount = 0;
-        int likeCount = 0;
-        int commentCount = 0;
+        int viewCount = postAdditionalRepository.countByPostId(postId);
+        int likeCount = memberPostLikeRepository.countByMemberPostLikeIdPostId(postId);
+        int commentCount = commentRepository.countByPostId(postId);
         return new PostStat(postId, viewCount, likeCount, commentCount);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -35,6 +35,7 @@ public class PostService {
         savePost(new Post(dto.getTitle(), dto.getContent(), member, image));
     }
 
+    @Transactional(readOnly = true)
     public PostResponseDto findPost(Integer currentMemberId, Integer postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -106,6 +108,18 @@ public class PostService {
                 imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
             }
         }
+    }
+
+    public long removePosts(LocalDate before, LocalDate after, Integer memberId) {
+        if (before == null && after == null && memberId == null) {
+            return 0; // 쿼리스트링 없으면 아무 작업 X
+        }
+
+        // LocalDateTime createdAt과 비교하기 위해 레포지터리가 아닌 서비스 계층에서 미리 변환
+        LocalDateTime convertedBefore = before != null ? before.plusDays(1).atStartOfDay() : null;
+        LocalDateTime convertedAfter = after != null ? after.atStartOfDay() : null;
+
+        return postRepository.deleteAllByIsDeletedTrueAndDynamicFilters(memberId, convertedBefore, convertedAfter);
     }
 
     private void savePost(Post post) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -6,8 +6,13 @@ import kakao_tech_bootcamp.community.dto.PostResponseDto;
 import kakao_tech_bootcamp.community.entity.*;
 import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -48,6 +53,18 @@ public class PostService {
         postStatRepository.save(postStat);
 
         return PostResponseDto.of(post, isLiked, postStat);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostResponseDto> findPosts(Integer currentMemberId, Integer lastPostId, Integer limit) {
+        Pageable pageable = PageRequest.of(0, limit, Sort.by("id").descending());
+        List<Post> posts = lastPostId == null
+                ? postRepository.findByIsDeletedFalseOrderByIdDesc(pageable)
+                : postRepository.findByIsDeletedFalseAndIdLessThanOrderByIdDesc(lastPostId, pageable);
+
+        return posts.stream().map(x -> PostResponseDto.of(x,
+                memberPostLikeRepository.existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(x.getId(), currentMemberId),
+                postStatRepository.findById(x.getId()).orElseGet(() -> findPostStat(x.getId())))).toList();
     }
 
     private void savePost(Post post) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -2,14 +2,8 @@ package kakao_tech_bootcamp.community.service;
 
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
 import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
-import kakao_tech_bootcamp.community.entity.Image;
-import kakao_tech_bootcamp.community.entity.Member;
-import kakao_tech_bootcamp.community.entity.Post;
-import kakao_tech_bootcamp.community.entity.PostAdditional;
-import kakao_tech_bootcamp.community.repository.ImageRepository;
-import kakao_tech_bootcamp.community.repository.MemberRepository;
-import kakao_tech_bootcamp.community.repository.PostAdditionalRepository;
-import kakao_tech_bootcamp.community.repository.PostRepository;
+import kakao_tech_bootcamp.community.entity.*;
+import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
     private final PostRepository postRepository;
     private final PostAdditionalRepository postAdditionalRepository;
+    private final PostStatRepository postStatRepository;
     private final MemberRepository memberRepository;
     private final ImageRepository imageRepository;
 
@@ -41,5 +36,6 @@ public class PostService {
     private void savePost(Post post) {
         Post savePost = postRepository.save(post);
         postAdditionalRepository.save(new PostAdditional(savePost));
+        postStatRepository.save(new PostStat(savePost.getId()));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -1,8 +1,10 @@
 package kakao_tech_bootcamp.community.service;
 
+import kakao_tech_bootcamp.community.common.exceptions.ForbiddenException;
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
 import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
 import kakao_tech_bootcamp.community.dto.PostResponseDto;
+import kakao_tech_bootcamp.community.dto.PostUpdateRequestDto;
 import kakao_tech_bootcamp.community.entity.*;
 import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -24,8 +26,9 @@ public class PostService {
     private final PostStatRepository postStatRepository;
     private final MemberPostLikeRepository memberPostLikeRepository;
     private final MemberRepository memberRepository;
-    private final ImageRepository imageRepository;
+    private final ImageRepository imageRepository; // TODO : 없애기
     private final CommentRepository commentRepository;
+    private final ImageService imageService;
 
     public void savePost(Integer currentMemberId, PostCreateRequestDto dto) {
         Member member = memberRepository.findById(currentMemberId)
@@ -65,6 +68,48 @@ public class PostService {
         return posts.stream().map(x -> PostResponseDto.of(x,
                 memberPostLikeRepository.existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(x.getId(), currentMemberId),
                 postStatRepository.findById(x.getId()).orElseGet(() -> findPostStat(x.getId())))).toList();
+    }
+
+    public void modifyPost(Integer currentMemberId, Integer postId, PostUpdateRequestDto dto) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
+
+        if (!Objects.equals(post.getMember().getId(), currentMemberId)) {
+            throw new ForbiddenException("게시글을 작성한 회원만 수정할 수 있습니다");
+        }
+
+        if (dto.getPostDeleted()) {
+            post.markDeleted(); // 관련 이미지 상태는 여전히 ACTIVE (배치 프로그램에 의해 삭제되지 않도록)
+            return; // soft delete 요청 시 그 외 게시글 수정 무시
+        }
+
+        if (dto.getTitle() != null) {
+            post.changeTitle(dto.getTitle());
+        }
+
+        if (dto.getContent() != null) {
+            post.changeContent(dto.getContent());
+        }
+
+        /*
+         이미지 삭제 true이고, 새 이미지도 전송하지 않았다면 기존 이미지 삭제 처리
+         만약 이미지 삭제 true더라도 새 이미지를 전송했다면 새로운 이미지로의 변경으로 간주함
+         */
+        if (dto.getImageDeleted() && dto.getImage() == null && post.getImage() != null) {
+            Image previousImage = post.getImage();
+            post.changeImage(null);
+            imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
+        }
+
+        if (dto.getImage() != null) {
+            Image previousImage = post.getImage();
+
+            Image currentImage = imageService.modifyImageStatusById(dto.getImage().getId(), ImageStatus.ACTIVE);
+            post.changeImage(currentImage);
+
+            if (previousImage != null) {
+                imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
+            }
+        }
     }
 
     private void savePost(Post post) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -26,7 +26,6 @@ public class PostService {
     private final PostStatRepository postStatRepository;
     private final MemberPostLikeRepository memberPostLikeRepository;
     private final MemberRepository memberRepository;
-    private final ImageRepository imageRepository; // TODO : 없애기
     private final CommentRepository commentRepository;
     private final ImageService imageService;
 
@@ -34,12 +33,9 @@ public class PostService {
         Member member = memberRepository.findById(currentMemberId)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
-        Image image = null;
-
-        if (dto.getImage() != null) {
-            image = imageRepository.findById(dto.getImage().getId())
-                    .orElseThrow(() -> new NotFoundException("이미지를 찾을 수 없습니다"));
-        }
+        Image image = dto.getImage() != null
+                ? imageService.modifyImageStatusById(dto.getImage().getId(), ImageStatus.ACTIVE)
+                : null;
 
         savePost(new Post(dto.getTitle(), dto.getContent(), member, image));
     }

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -38,7 +38,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostResponseDto findPost(Integer currentMemberId, Integer postId) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
 
         PostStat postStat = postStatRepository.findById(postId).orElseGet(() -> findPostStat(postId));

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -1,0 +1,45 @@
+package kakao_tech_bootcamp.community.service;
+
+import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
+import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
+import kakao_tech_bootcamp.community.entity.Image;
+import kakao_tech_bootcamp.community.entity.Member;
+import kakao_tech_bootcamp.community.entity.Post;
+import kakao_tech_bootcamp.community.entity.PostAdditional;
+import kakao_tech_bootcamp.community.repository.ImageRepository;
+import kakao_tech_bootcamp.community.repository.MemberRepository;
+import kakao_tech_bootcamp.community.repository.PostAdditionalRepository;
+import kakao_tech_bootcamp.community.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+    private final PostAdditionalRepository postAdditionalRepository;
+    private final MemberRepository memberRepository;
+    private final ImageRepository imageRepository;
+
+    public void savePost(Integer currentMemberId, PostCreateRequestDto dto) {
+        Member member = memberRepository.findById(currentMemberId)
+                .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
+
+        Image image = null;
+
+        if (dto.getImage() != null) {
+            image = imageRepository.findById(dto.getImage().getId())
+                    .orElseThrow(() -> new NotFoundException("이미지를 찾을 수 없습니다"));
+        }
+
+        savePost(new Post(dto.getTitle(), dto.getContent(), member, image));
+    }
+
+    private void savePost(Post post) {
+        Post savePost = postRepository.save(post);
+        postAdditionalRepository.save(new PostAdditional(savePost));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
 
   multipart:
     max-file-size: 10MB


### PR DESCRIPTION
## 작업 내용
- Post, PostAdditional 엔티티 수정
    - `@Setter` 제거 및 필드 값 변경 메서드 별도 정의
    - PostAdditional에서 `@MapsId` 사용해 PostAdditional의 기본키(id)가 Post의 기본키(id)와 공유되며 외래키 역할을 수행함을 나타냄
- 게시글 CRUD API 생성
    > **게시글 조회/상세조회 부분은 좋아요, 댓글까지 구현된 이후 성능 개선 필요**
    - QueryDSL의 where 다중 파라미터로 hard delete 구현
- 게시글 조회수, 좋아요수, 댓글수 관리하는 `PostStat` 엔티티와 레포지터리 생성
    - 캐싱용 인메모리 데이터베이스
- 모든 엔티티에서 `fetchType.LAZY` 설정

<br>
<br>
<br>

## 고민 내용
### RDB에서 PostStat 조회 방법
- RDB에서 조회해야 하는 상황
    - 인메모리 데이터베이스에 해당 게시글에 대한 PostStat이 캐싱돼 있지 않아 데이터베이스에서 직접 조회해야 하는 경우
- 고민한 방식: `하나의 쿼리로 한꺼번에 조회하기 vs 각 테이블에서 각각 조회해 합치기`
    - 하나의 쿼리로 한꺼번에 조회하기
        - 기존 Post 엔티티에 PostAdditional, MemberPostLike, Comment 엔티티와 양방향 매핑 설정 필요
        - JPQL로 작성하기 복잡 _(시도했지만 계속 쿼리 생성 실패... 아예 불가능할지도)_
        - 네티이브 쿼리로 작성해도 여러 조인으로 인해 행이 많아지고, DISTINCT로 중복을 제거해야 해 성능 느려짐
    - 각 테이블에서 각각 조회해 합치기
        - 3번의 쿼리 실행 필요하다는 단점
        - 그러나 깔끔함
- `결론` 각 테이블에서 각각 조회해 합치기 선택
    - 애초에 이 쿼리가 실행 빈도가 무척 낮음 (= RDB에서 직접 통계 쿼리 날릴 일이 많지 않음)
        - 애플리케이션 첫 가동 시 RDB에서 전체 게시글의 PostStat을 인메모리 디비에 적재
        - 이후 새 게시글 등록 시 인메모리 디비에 해당 게시글에 대한 PostStat 추가
    - 즉, 인메모리 디비에 캐싱돼 있지 않을 때만 호출하는데 애초에 그럴 확률이 적음!
    - 따라서 각 테이블에서 조회해 3번의 쿼리를 실행하더라도 괜찮다고 판단함

<br>

### 게시글 조회 시 로그인한 회원의 좋아요 여부 가져오는 방법
- 고민한 방식: `좋아요 여부까지 PostResponseDto 프로젝션으로 한꺼번에 조회하기 vs 게시글 조회와 좋아요 여부 따로 조회하기`
- DTO 프로젝션으로 한꺼번에 조회하고 싶었지만
    ```java
    @Getter
    @AllArgsConstructor
    public class PostResponseTempDto {
        private Integer id;
        private String title;
        private String content;
        private Member member;
        private Image image;
        private LocalDateTime createdAt;
        private boolean isLiked;
    
        public static PostResponseTempDto of(Post post, boolean isLiked) {
            return new PostResponseTempDto(post.getId(), post.getTitle(), post.getContent(),
                    post.getMember(),
                    post.getImage(),
                    post.getCreatedAt(), isLiked);
        }
    }
    
    @Repository
    public interface PostRepository extends JpaRepository<Post, Integer> {
        @Query("""
                select new kakao_tech_bootcamp.community.dto.PostResponseTempDto(
                    p.id, p.title, p.content, m.*, i.*, p.createdAt,
                    exists(
                        select 1 from MemberPostLike mpl
                        where mpl.memberPostLikeId.postId = p.id
                          and mpl.memberPostLikeId.memberId = :memberId
                    )
                )
                from Post p join fetch p.member m join fetch p.image i
                where p.id = :postId
                """)
        Optional<PostResponseTempDto> findPostResponseDtoById(@Param("postId") Integer postId, @Param("memberId") Integer memberId);
    }
    ```
    - Post의 member와 image는 LAZY Loading → 직렬화 시 오류나지 않도록 fetch join 필요 → 그러나 DTO 프로젝션과 fetch join 함께 사용 불가
        - 직렬화 규칙을 느슨하게 바꾸는 방법도 있지만 규칙을 느슨하게 만들고 싶진 않음
    - 네이티브 쿼리를 떠올렸지만 자주 사용하는 만큼 유지보수성을 고려해 최대한 지양하고 싶었음
    - 우선 성능 차차 개선하기로 하고, 가장 깔끔한 방식인 게시글과 좋아요 여부 따로 조회한 후 서비스 계층에서 합쳐 반환하기로 결정
        - **좋아요, 댓글 API 모두 구현 후 게시글 조회/상세조회 성능 개선 때 다시 한 번 더 고민할 예정**

<br>
<br>
<br>

## 화면 캡처
- 전체 조회
    <img width="774" height="1051" alt="image" src="https://github.com/user-attachments/assets/46db5797-63d6-4529-9bb8-41da9d1f2d99" />

- 수정
    <img width="1836" height="492" alt="image" src="https://github.com/user-attachments/assets/452eded5-8322-4834-a2fd-31ab0ebd68f8" />

- 삭제 (soft delete)
    <img width="1786" height="482" alt="image" src="https://github.com/user-attachments/assets/df5aeaad-4947-47d2-aa45-22bff725e22f" />

- 삭제 (hard delete)
    <img width="530" height="279" alt="image" src="https://github.com/user-attachments/assets/dd2945f9-179b-44eb-877f-5da4682bb180" />
