### PR TITLE
[feat] 댓글 API 생성

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/common/ApiResponse.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/ApiResponse.java
@@ -2,11 +2,8 @@ package kakao_tech_bootcamp.community.common;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter @Setter
-@NoArgsConstructor
+@Getter
 @AllArgsConstructor
 public class ApiResponse<T> {
     private String message;

--- a/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
@@ -12,33 +12,33 @@ import java.util.List;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<List<String>>> methodArgumentNotValidException(MethodArgumentNotValidException e) {
         List<String> errors = e.getFieldErrors().stream().map(fieldError -> fieldError.getDefaultMessage()).toList();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("invalid_request", errors));
     }
 
     @ExceptionHandler(value = BadRequestException.class)
-    public ResponseEntity<ApiResponse> badRequestException(BadRequestException e) {
+    public ResponseEntity<ApiResponse<String>> badRequestException(BadRequestException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("invalid_request", e.getMessage()));
     }
 
     @ExceptionHandler(value = UnauthorizedException.class)
-    public ResponseEntity<ApiResponse> unauthorizedException(UnauthorizedException e) {
+    public ResponseEntity<ApiResponse<String>> unauthorizedException(UnauthorizedException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse<>("not_authenticated", e.getMessage()));
     }
 
     @ExceptionHandler(value = ForbiddenException.class)
-    public ResponseEntity<ApiResponse> forbiddenException(ForbiddenException e) {
+    public ResponseEntity<ApiResponse<String>> forbiddenException(ForbiddenException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ApiResponse<>("not_authorized", e.getMessage()));
     }
 
     @ExceptionHandler(value = NotFoundException.class)
-    public ResponseEntity<ApiResponse> notFoundException(NotFoundException e) {
+    public ResponseEntity<ApiResponse<String>> notFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>("not_found", e.getMessage()));
     }
 
     @ExceptionHandler(value = ConflictException.class)
-    public ResponseEntity<ApiResponse> conflictException(ConflictException e) {
+    public ResponseEntity<ApiResponse<String>> conflictException(ConflictException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(new ApiResponse<>("conflict_request", e.getMessage()));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse> logout(@RequestBody @Validated AuthRequestDto authRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> logout(@RequestBody @Validated AuthRequestDto authRequestDto) {
         String sessionId = authStrategy.issue(authRequestDto);
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId)
                 .httpOnly(true)
@@ -36,7 +36,7 @@ public class AuthController {
     }
 
     @DeleteMapping
-    public ResponseEntity logout(@CookieValue("sid") String sessionId) {
+    public ResponseEntity<ApiResponse<Void>> logout(@CookieValue("sid") String sessionId) {
         authStrategy.invalidate(sessionId);
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId).maxAge(0).build();
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -26,5 +27,13 @@ public class CommentController {
                                                    @RequestBody @Validated CommentRequestDto commentRequestDto) {
         CommentResponseDto comment = commentService.saveComment(authInfo.getId(), postId, commentRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("comment_create_success", Map.of("comment", comment)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse> findComments(@PathVariable Integer postId,
+                                                   @RequestParam(value = "lastCommentId", required = false) Integer lastCommentId,
+                                                   @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+        List<CommentResponseDto> comments = commentService.findComments(postId, lastCommentId, limit);
+        return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("comments", comments)));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -47,10 +47,10 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ApiResponse<Void>> removeComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<Void> removeComment(@CurrentMember AuthInfo authInfo,
                                                      @PathVariable("postId") Integer postId,
                                                      @PathVariable("commentId") Integer commentId) {
         commentService.removeComment(authInfo.getId(), postId, commentId);
-        return ResponseEntity.ok(new ApiResponse<>("ok", null));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -1,0 +1,30 @@
+package kakao_tech_bootcamp.community.controller;
+
+import kakao_tech_bootcamp.community.common.ApiResponse;
+import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
+import kakao_tech_bootcamp.community.dto.CommentRequestDto;
+import kakao_tech_bootcamp.community.dto.CommentResponseDto;
+import kakao_tech_bootcamp.community.service.AuthInfo;
+import kakao_tech_bootcamp.community.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> saveComment(@CurrentMember AuthInfo authInfo,
+                                                   @PathVariable Integer postId,
+                                                   @RequestBody @Validated CommentRequestDto commentRequestDto) {
+        CommentResponseDto comment = commentService.saveComment(authInfo.getId(), postId, commentRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("comment_create_success", Map.of("comment", comment)));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -36,4 +36,13 @@ public class CommentController {
         List<CommentResponseDto> comments = commentService.findComments(postId, lastCommentId, limit);
         return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("comments", comments)));
     }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<ApiResponse> modifyComment(@CurrentMember AuthInfo authInfo,
+                                                     @PathVariable("postId") Integer postId,
+                                                     @PathVariable("commentId") Integer commentId,
+                                                     @RequestBody @Validated CommentRequestDto commentRequestDto) {
+        CommentResponseDto comment = commentService.modifyComment(authInfo.getId(), postId, commentId, commentRequestDto);
+        return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("data", comment)));
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -38,12 +38,12 @@ public class CommentController {
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<ApiResponse<Map<String, CommentResponseDto>>> modifyComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, Object>>> modifyComment(@CurrentMember AuthInfo authInfo,
                                                      @PathVariable("postId") Integer postId,
                                                      @PathVariable("commentId") Integer commentId,
                                                      @RequestBody @Validated CommentRequestDto commentRequestDto) {
-        CommentResponseDto comment = commentService.modifyComment(authInfo.getId(), postId, commentId, commentRequestDto);
-        return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("data", comment)));
+        Map<String, Object> modifiedFiles = commentService.modifyComment(authInfo.getId(), postId, commentId, commentRequestDto);
+        return ResponseEntity.ok(new ApiResponse<>("ok", modifiedFiles));
     }
 
     @DeleteMapping("/{commentId}")

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -22,7 +22,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse> saveComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, CommentResponseDto>>> saveComment(@CurrentMember AuthInfo authInfo,
                                                    @PathVariable Integer postId,
                                                    @RequestBody @Validated CommentRequestDto commentRequestDto) {
         CommentResponseDto comment = commentService.saveComment(authInfo.getId(), postId, commentRequestDto);
@@ -30,7 +30,7 @@ public class CommentController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse> findComments(@PathVariable Integer postId,
+    public ResponseEntity<ApiResponse<Map<String, List<CommentResponseDto>>>> findComments(@PathVariable Integer postId,
                                                    @RequestParam(value = "lastCommentId", required = false) Integer lastCommentId,
                                                    @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
         List<CommentResponseDto> comments = commentService.findComments(postId, lastCommentId, limit);
@@ -38,7 +38,7 @@ public class CommentController {
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<ApiResponse> modifyComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, CommentResponseDto>>> modifyComment(@CurrentMember AuthInfo authInfo,
                                                      @PathVariable("postId") Integer postId,
                                                      @PathVariable("commentId") Integer commentId,
                                                      @RequestBody @Validated CommentRequestDto commentRequestDto) {
@@ -47,7 +47,7 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ApiResponse> removeComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Void>> removeComment(@CurrentMember AuthInfo authInfo,
                                                      @PathVariable("postId") Integer postId,
                                                      @PathVariable("commentId") Integer commentId) {
         commentService.removeComment(authInfo.getId(), postId, commentId);

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -45,4 +45,12 @@ public class CommentController {
         CommentResponseDto comment = commentService.modifyComment(authInfo.getId(), postId, commentId, commentRequestDto);
         return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("data", comment)));
     }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse> removeComment(@CurrentMember AuthInfo authInfo,
+                                                     @PathVariable("postId") Integer postId,
+                                                     @PathVariable("commentId") Integer commentId) {
+        commentService.removeComment(authInfo.getId(), postId, commentId);
+        return ResponseEntity.ok(new ApiResponse<>("ok", null));
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/ImageController.java
@@ -25,14 +25,15 @@ public class ImageController {
     }
 
     @PostMapping("/members")
-    public ResponseEntity<ApiResponse> saveMemberImage(@RequestParam("file") MultipartFile file) throws IOException {
+    public ResponseEntity<ApiResponse<Map<String, ImageResponseDto>>> saveMemberImage(@RequestParam("file") MultipartFile file) throws IOException {
         ImageResponseDto imageResponseDto = imageService.saveImage("members", file);
         Map<String, ImageResponseDto> data = Map.of("image", imageResponseDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("upload_success", data));
     }
 
     @PostMapping("/posts")
-    public ResponseEntity<ApiResponse> savePostImage(@CurrentMember AuthInfo authInfo, @RequestParam("file") MultipartFile file) throws IOException {
+    public ResponseEntity<ApiResponse<Map<String, ImageResponseDto>>> savePostImage(@CurrentMember AuthInfo authInfo,
+                                                                                    @RequestParam("file") MultipartFile file) throws IOException {
         ImageResponseDto imageResponseDto = imageService.saveImage("posts", file);
         Map<String, ImageResponseDto> data = Map.of("image", imageResponseDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("upload_success", data));

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -24,31 +24,31 @@ public class MemberController {
     }
 
     @PostMapping("/availability/email")
-    public ResponseEntity<ApiResponse> isAvailableEmail(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
+    public ResponseEntity<ApiResponse<Void>> isAvailableEmail(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
         memberService.existsByEmail(memberAvailabilityDto);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", null));
     }
 
     @PostMapping("/availability/nickname")
-    public ResponseEntity<ApiResponse> isAvailableNickname(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
+    public ResponseEntity<ApiResponse<Void>> isAvailableNickname(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
         memberService.existsByNickname(memberAvailabilityDto);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", null));
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse> saveMember(@RequestBody @Validated MemberCreateRequestDto memberCreateRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> saveMember(@RequestBody @Validated MemberCreateRequestDto memberCreateRequestDto) {
         memberService.saveMember(memberCreateRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("register_success", null));
     }
 
     @GetMapping("/{memberId}")
-    public ResponseEntity<ApiResponse> findMember(@PathVariable Integer memberId) {
-        Map<String, MemberResponseDto> data = Map.of("member", memberService.findMember(memberId));
-        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", data));
+    public ResponseEntity<ApiResponse<Map<String, MemberResponseDto>>> findMember(@PathVariable Integer memberId) {
+        MemberResponseDto member = memberService.findMember(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", Map.of("member", member)));
     }
 
     @PatchMapping("/{memberId}")
-    public ResponseEntity modifyMember(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<Void> modifyMember(@CurrentMember AuthInfo authInfo,
                                        @PathVariable Integer memberId,
                                        @RequestBody @Validated MemberUpdateRequestDto updateMemberRequestDto) {
         memberService.modifyMember(authInfo.getId(), memberId, updateMemberRequestDto);
@@ -56,7 +56,7 @@ public class MemberController {
     }
 
     @DeleteMapping("/{memberId}")
-    public ResponseEntity removeMember(@CurrentMember AuthInfo authInfo, @PathVariable Integer memberId) {
+    public ResponseEntity<Void> removeMember(@CurrentMember AuthInfo authInfo, @PathVariable Integer memberId) {
         memberService.removeMember(authInfo.getId(), memberId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -24,14 +24,14 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse> savePost(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Void>> savePost(@CurrentMember AuthInfo authInfo,
                                                 @RequestBody PostCreateRequestDto postCreateRequestDto) {
         postService.savePost(authInfo.getId(), postCreateRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("post_create_success", null));
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse> findPosts(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, List<PostResponseDto>>>> findPosts(@CurrentMember AuthInfo authInfo,
                                                  @RequestParam(value = "lastPostId", required = false) Integer lastPostId,
                                                  @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
         List<PostResponseDto> posts = postService.findPosts(authInfo.getId(), lastPostId, limit);
@@ -39,13 +39,13 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<ApiResponse> findPost(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
+    public ResponseEntity<ApiResponse<Map<String, PostResponseDto>>> findPost(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
         PostResponseDto post = postService.findPost(authInfo.getId(), postId);
         return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("post", post)));
     }
 
     @PatchMapping("/{postId}")
-    public ResponseEntity modifyPost(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<Void> modifyPost(@CurrentMember AuthInfo authInfo,
                                                   @PathVariable Integer postId,
                                                   @RequestBody @Validated PostUpdateRequestDto postUpdateRequestDto) {
         postService.modifyPost(authInfo.getId(), postId, postUpdateRequestDto);
@@ -53,7 +53,7 @@ public class PostController {
     }
 
     @DeleteMapping
-    public ResponseEntity<ApiResponse> removePosts(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, Long>>> removePosts(@CurrentMember AuthInfo authInfo,
                                       @RequestParam(value = "before", required = false) LocalDate before,
                                       @RequestParam(value = "after", required = false) LocalDate after,
                                       @RequestParam(value = "writer", required = false) Integer memberId) {

--- a/src/main/java/kakao_tech_bootcamp/community/dto/CommentRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/CommentRequestDto.java
@@ -1,0 +1,10 @@
+package kakao_tech_bootcamp.community.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CommentRequestDto {
+    @NotBlank(message = "내용이 존재하지 않습니다")
+    private String content;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/CommentResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/CommentResponseDto.java
@@ -1,0 +1,21 @@
+package kakao_tech_bootcamp.community.dto;
+
+import kakao_tech_bootcamp.community.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponseDto {
+    private Integer id;
+    private MemberResponseDto member;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static CommentResponseDto of(Comment comment) {
+        return new CommentResponseDto(comment.getId(), MemberResponseDto.of(comment.getMember()),
+                comment.getContent(), comment.getCreatedAt());
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Comment.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Comment.java
@@ -12,8 +12,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "comment")
-@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class Comment {
@@ -43,6 +43,10 @@ public class Comment {
     public Comment(Post post, Member member, String content) {
         this.post = post;
         this.member = member;
+        this.content = content;
+    }
+
+    public void changeContent(String content) {
         this.content = content;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/CommentRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/CommentRepository.java
@@ -1,10 +1,20 @@
 package kakao_tech_bootcamp.community.repository;
 
 import kakao_tech_bootcamp.community.entity.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
     int countByPostId(Integer postId);
+
+    @EntityGraph(attributePaths = {"member", "member.image"})
+    List<Comment> findByPostIdOrderByIdDesc(Integer postId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "member.image"})
+    List<Comment> findByPostIdAndIdLessThanOrderByIdDesc(Integer postId, Integer lastCommentId, Pageable pageable);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
@@ -8,9 +8,9 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Integer> {
-    public boolean existsByEmail(String email);
+    boolean existsByEmail(String email);
 
-    public boolean existsByNickname(String nickname);
+    boolean existsByNickname(String nickname);
 
-    public Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostAdditionalRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostAdditionalRepository.java
@@ -2,9 +2,12 @@ package kakao_tech_bootcamp.community.repository;
 
 import kakao_tech_bootcamp.community.entity.PostAdditional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostAdditionalRepository extends JpaRepository<PostAdditional, Integer> {
-    int countByPostId(Integer postId);
+    @Query("select pa.viewCount from PostAdditional pa where pa.id = :postId")
+    Integer findViewCountByPostId(@Param("postId") Integer postId);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Service
@@ -46,7 +47,7 @@ public class CommentService {
         return comments.stream().map(CommentResponseDto::of).toList();
     }
 
-    public CommentResponseDto modifyComment(Integer currentMemberId, Integer postId, Integer commentId, CommentRequestDto dto) {
+    public Map<String, Object> modifyComment(Integer currentMemberId, Integer postId, Integer commentId, CommentRequestDto dto) {
         postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다"));
 
@@ -56,7 +57,7 @@ public class CommentService {
 
         comment.changeContent(dto.getContent());
 
-        return CommentResponseDto.of(comment);
+        return Map.of("content", comment.getContent());
     }
 
     public void removeComment(Integer currentMemberId, Integer postId, Integer commentId) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -39,7 +39,7 @@ public class CommentService {
     public List<CommentResponseDto> findComments(Integer postId, Integer lastCommentId, Integer limit) {
         postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
 
-        Pageable pageable = PageRequest.of(0, limit, Sort.by("id").descending());
+        Pageable pageable = PageRequest.of(0, limit);
         List<Comment> comments = lastCommentId == null
                 ? commentRepository.findByPostIdOrderByIdDesc(postId, pageable)
                 : commentRepository.findByPostIdAndIdLessThanOrderByIdDesc(postId, lastCommentId, pageable);

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -10,9 +10,16 @@ import kakao_tech_bootcamp.community.repository.CommentRepository;
 import kakao_tech_bootcamp.community.repository.MemberRepository;
 import kakao_tech_bootcamp.community.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
@@ -20,9 +27,21 @@ public class CommentService {
     private final MemberRepository memberRepository;
 
     public CommentResponseDto saveComment(Integer currentMemberId, Integer postId, CommentRequestDto dto) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
         Member member = memberRepository.findById(currentMemberId).orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
         Comment comment = commentRepository.save(new Comment(post, member, dto.getContent()));
         return CommentResponseDto.of(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> findComments(Integer postId, Integer lastCommentId, Integer limit) {
+        postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
+
+        Pageable pageable = PageRequest.of(0, limit, Sort.by("id").descending());
+        List<Comment> comments = lastCommentId == null
+                ? commentRepository.findByPostIdOrderByIdDesc(postId, pageable)
+                : commentRepository.findByPostIdAndIdLessThanOrderByIdDesc(postId, lastCommentId, pageable);
+
+        return comments.stream().map(CommentResponseDto::of).toList();
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -13,7 +13,6 @@ import kakao_tech_bootcamp.community.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -1,5 +1,6 @@
 package kakao_tech_bootcamp.community.service;
 
+import kakao_tech_bootcamp.community.common.exceptions.ForbiddenException;
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
 import kakao_tech_bootcamp.community.dto.CommentRequestDto;
 import kakao_tech_bootcamp.community.dto.CommentResponseDto;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -43,5 +45,18 @@ public class CommentService {
                 : commentRepository.findByPostIdAndIdLessThanOrderByIdDesc(postId, lastCommentId, pageable);
 
         return comments.stream().map(CommentResponseDto::of).toList();
+    }
+
+    public CommentResponseDto modifyComment(Integer currentMemberId, Integer postId, Integer commentId, CommentRequestDto dto) {
+        postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다"));
+
+        if (Objects.equals(comment.getMember().getId(), currentMemberId)) {
+            throw new ForbiddenException("댓글을 작성한 회원만 수정할 수 있습니다");
+        }
+
+        comment.changeContent(dto.getContent());
+
+        return CommentResponseDto.of(comment);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -51,12 +51,23 @@ public class CommentService {
         postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다"));
 
-        if (Objects.equals(comment.getMember().getId(), currentMemberId)) {
+        if (!Objects.equals(comment.getMember().getId(), currentMemberId)) {
             throw new ForbiddenException("댓글을 작성한 회원만 수정할 수 있습니다");
         }
 
         comment.changeContent(dto.getContent());
 
         return CommentResponseDto.of(comment);
+    }
+
+    public void removeComment(Integer currentMemberId, Integer postId, Integer commentId) {
+        postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다"));
+
+        if (!Objects.equals(comment.getMember().getId(), currentMemberId)) {
+            throw new ForbiddenException("댓글을 작성한 회원만 삭제할 수 있습니다");
+        }
+
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -1,0 +1,28 @@
+package kakao_tech_bootcamp.community.service;
+
+import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
+import kakao_tech_bootcamp.community.dto.CommentRequestDto;
+import kakao_tech_bootcamp.community.dto.CommentResponseDto;
+import kakao_tech_bootcamp.community.entity.Comment;
+import kakao_tech_bootcamp.community.entity.Member;
+import kakao_tech_bootcamp.community.entity.Post;
+import kakao_tech_bootcamp.community.repository.CommentRepository;
+import kakao_tech_bootcamp.community.repository.MemberRepository;
+import kakao_tech_bootcamp.community.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    public CommentResponseDto saveComment(Integer currentMemberId, Integer postId, CommentRequestDto dto) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
+        Member member = memberRepository.findById(currentMemberId).orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
+        Comment comment = commentRepository.save(new Comment(post, member, dto.getContent()));
+        return CommentResponseDto.of(comment);
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -58,7 +58,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public List<PostResponseDto> findPosts(Integer currentMemberId, Integer lastPostId, Integer limit) {
-        Pageable pageable = PageRequest.of(0, limit, Sort.by("id").descending());
+        Pageable pageable = PageRequest.of(0, limit);
         List<Post> posts = lastPostId == null
                 ? postRepository.findByIsDeletedFalseOrderByIdDesc(pageable)
                 : postRepository.findByIsDeletedFalseAndIdLessThanOrderByIdDesc(lastPostId, pageable);

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -128,7 +128,7 @@ public class PostService {
     }
 
     private PostStat findPostStat(Integer postId) {
-        int viewCount = postAdditionalRepository.countByPostId(postId);
+        int viewCount = postAdditionalRepository.findViewCountByPostId(postId);
         int likeCount = memberPostLikeRepository.countByMemberPostLikeIdPostId(postId);
         int commentCount = commentRepository.countByPostId(postId);
         return new PostStat(postId, viewCount, likeCount, commentCount);

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -10,7 +10,6 @@ import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 


### PR DESCRIPTION
## 작업 내용
- Comment 엔티티 수정
    - `@Setter` 제거 및 content 필드 값 변경 메서드 별도 정의
- 댓글 CRUD API 생성
- PostAdditional의 viewCount 조회 메서드명 수정
    - 기존 countByPostId 사용
        - viewCount 필드가 따로 존재하므로 count가 아니라 직접 필드 조회하면 됨
    - `@Query`로 JPQL 작성한 findViewCountByPostId 메서드 생성
- 각 컨트롤러에서 ApiResponse 타입 파라미터 명시하도록 수정
<br>
<br>
<br>

## 고민 내용
### POST, PATCH, DELETE 요청에 대한 응답 데이터 고민
- 기존: NoContent 혹은 data 필드를 null로 응답
- 문제점
    - 그러나 API 테스트를 진행할 때 변경사항 확인하려면 별도로 조회해야 한다는 불편함과 더불어 실제 클라이언트 입장에서 요청에 대한 확실한 처리 결과를 한눈에 파악하기 어렵다고 판단함
    - 예를 들어 게시글 PATCH 요청 시 204 응답만 나와 어떤 변경사항이 반영됐는지 파악하기 어려움
        - `postDeleted: true`와 함께 다른 데이터를 함께 전달했을 때 204 응답 (=> 게시글 soft delete 처리)
        - `imageDeleted: true`와 `image: { ... }를 함께 전달해도 204 응답 (=> 게시글 이미지 삭제 요청 무시되고 이미지 변경함)
        - 게시글 hard delete 요청 시 204만 나와 실제 테이블 행이 삭제된 건지, 아님 원래 없던 행이라서 delete 적용이 안 된 건지 파악 불가
    - 또한 클라이언트 입장에서 편리함 증가
        - 예를 들어 게시글 수정 시 수정 결과를 바로 반환받으면 다시 게시글 정보를 fetch하지 않고 바로 반영 가능
- `결론` POST, PATCH에 적절한 데이터 포함해 응답하기로 수정
    - POST 시 새로 생성된 데이터의 id 반환 (필요하다면 다른 데이터도 포함)
    - PATCH 시 변경된 필드들 반환 (변경 대상 아니면 포함 X)

<br>
<br>
<br>

## 화면 캡처
- 전체 조회
    <img width="800" height="779" alt="image" src="https://github.com/user-attachments/assets/800a2b80-f9f4-45ba-8f83-b4b65a5a126e" />

- 생성
    <img width="638" height="669" alt="image" src="https://github.com/user-attachments/assets/a9dbb272-55ff-473c-9a22-e0b8dbd8bab3" />

- 수정
    <img width="640" height="406" alt="image" src="https://github.com/user-attachments/assets/f6eaf5bb-f60a-4515-a413-f22f681b0c77" />

- 삭제
    - 정상적인 삭제 (댓글과 댓글이 달린 게시글 존재)
        <img width="632" height="160" alt="image" src="https://github.com/user-attachments/assets/dd1be7e4-9fa2-47da-9e86-c500a21a9c9f" />

    - 본인이 작성한 게 아닌 댓글 삭제
        <img width="633" height="237" alt="image" src="https://github.com/user-attachments/assets/ba176301-4961-4d76-bc89-002bd35af617" />

    - 댓글이 없을 때
        <img width="631" height="236" alt="image" src="https://github.com/user-attachments/assets/b5fc5181-b69a-4627-bdb0-5d74e11c7f66" />

    - 게시글이 없을 때
        <img width="628" height="244" alt="image" src="https://github.com/user-attachments/assets/e4273917-e8e6-481d-83cf-72d9d621eb3f" />
