### PR TITLE
[feat] 좋아요 API 생성

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberPostLikeController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberPostLikeController.java
@@ -1,0 +1,30 @@
+package kakao_tech_bootcamp.community.controller;
+
+import kakao_tech_bootcamp.community.common.ApiResponse;
+import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
+import kakao_tech_bootcamp.community.service.AuthInfo;
+import kakao_tech_bootcamp.community.service.MemberPostLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/posts/{postId}/likes")
+@RequiredArgsConstructor
+public class MemberPostLikeController {
+    private final MemberPostLikeService likeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Map<String, Integer>>> saveLike(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
+        int likeCount = likeService.saveLike(authInfo.getId(), postId);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ApiResponse<>("like_create_success", Map.of("likeCount", likeCount)));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberPostLikeController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberPostLikeController.java
@@ -7,10 +7,7 @@ import kakao_tech_bootcamp.community.service.MemberPostLikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -26,5 +23,11 @@ public class MemberPostLikeController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(new ApiResponse<>("like_create_success", Map.of("likeCount", likeCount)));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Map<String, Integer>>> removeLike(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
+        int likeCount = likeService.removeLike(authInfo.getId(), postId);
+        return ResponseEntity.ok(new ApiResponse<>("like_delete_success", Map.of("likeCount", likeCount)));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/entity/MemberPostLike.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/MemberPostLike.java
@@ -4,15 +4,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "member_post_like")
-@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class MemberPostLike {
@@ -23,7 +22,7 @@ public class MemberPostLike {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public MemberPostLike(Post post, Member member) {
-        memberPostLikeId = new MemberPostLikeId(post.getId(), member.getId());
+    public MemberPostLike(Integer postId, Integer memberId) {
+        memberPostLikeId = new MemberPostLikeId(postId, memberId);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Integer>, PostRepositoryCustom {
     Optional<Post> findByIdAndIsDeletedFalse(Integer postId);
 
+    boolean existsByIdAndIsDeletedFalse(Integer postId);
+
     // TODO: 카디널리티 폭발... 해결 필요
     @EntityGraph(attributePaths = {"member", "member.image", "image"})
     List<Post> findByIsDeletedFalseOrderByIdDesc(Pageable pageable);

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberPostLikeService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberPostLikeService.java
@@ -3,6 +3,7 @@ package kakao_tech_bootcamp.community.service;
 import kakao_tech_bootcamp.community.common.exceptions.ConflictException;
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
 import kakao_tech_bootcamp.community.entity.MemberPostLike;
+import kakao_tech_bootcamp.community.entity.MemberPostLikeId;
 import kakao_tech_bootcamp.community.entity.PostStat;
 import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,26 @@ public class MemberPostLikeService {
 
         PostStat postStat = postStatRepository.findById(postId).orElseGet(() -> findPostStat(postId));
         postStat.incrementLikeCount();
+        postStatRepository.save(postStat);
+
+        return postStat.getLikeCount();
+    }
+
+    public int removeLike(Integer currentMemberId, Integer postId) {
+        if (!postRepository.existsByIdAndIsDeletedFalse(postId)) {
+            throw new NotFoundException("게시글을 찾을 수 없습니다");
+        }
+
+        boolean likeExists = likeRepository.existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(postId, currentMemberId);
+
+        if (!likeExists) {
+            throw new NotFoundException("좋아요를 찾을 수 없습니다");
+        }
+
+        likeRepository.deleteById(new MemberPostLikeId(postId, currentMemberId));
+
+        PostStat postStat = postStatRepository.findById(postId).orElseGet(() -> findPostStat(postId));
+        postStat.decrementLikeCount();
         postStatRepository.save(postStat);
 
         return postStat.getLikeCount();

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberPostLikeService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberPostLikeService.java
@@ -1,0 +1,51 @@
+package kakao_tech_bootcamp.community.service;
+
+import kakao_tech_bootcamp.community.common.exceptions.ConflictException;
+import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
+import kakao_tech_bootcamp.community.entity.MemberPostLike;
+import kakao_tech_bootcamp.community.entity.PostStat;
+import kakao_tech_bootcamp.community.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberPostLikeService {
+    private final MemberPostLikeRepository likeRepository;
+    private final PostStatRepository postStatRepository;
+    private final PostRepository postRepository;
+    private final PostAdditionalRepository postAdditionalRepository;
+    private final MemberPostLikeRepository memberPostLikeRepository;
+    private final CommentRepository commentRepository;
+
+    public int saveLike(Integer currentMemberId, Integer postId) {
+        if (!postRepository.existsByIdAndIsDeletedFalse(postId)) {
+            throw new NotFoundException("게시글을 찾을 수 없습니다");
+        }
+
+        boolean likeExists = likeRepository.existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(postId, currentMemberId);
+
+        if (likeExists) {
+            throw new ConflictException("회원이 이미 좋아요한 게시글입니다");
+        }
+
+        likeRepository.save(new MemberPostLike(postId, currentMemberId));
+
+        PostStat postStat = postStatRepository.findById(postId).orElseGet(() -> findPostStat(postId));
+        postStat.incrementLikeCount();
+        postStatRepository.save(postStat);
+
+        return postStat.getLikeCount();
+    }
+
+    // TODO: PostService와 중복 메서드. PostStatService 따로 빼내야 할 듯
+    private PostStat findPostStat(Integer postId) {
+        int viewCount = postAdditionalRepository.findViewCountByPostId(postId);
+        int likeCount = memberPostLikeRepository.countByMemberPostLikeIdPostId(postId);
+        int commentCount = commentRepository.countByPostId(postId);
+        return new PostStat(postId, viewCount, likeCount, commentCount);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Like 엔티티 수정
    - `@Setter` 제거
    - 생성자의 매개변수 타입 Post, Member 엔티티 → Integer postId, Integer memberId로 변경
        - 성능 측면에서 불필요한 엔티티 호출 최소화하기 위함
- Like 생성 및 삭제 API 생성

<br>
<br>
<br>

## 고민 내용
### PostStat (조회수, 좋아요수, 댓글수 통계) 관리 위치에 대한 고촬
- #8 참고

<br>
<br>
<br>

## 화면 캡처
- 생성
    - 정상적인 좋아요 생성
        <img width="515" height="277" alt="image" src="https://github.com/user-attachments/assets/1a600129-fbd9-4069-80f9-6b6c973c6a2a" />

    - 이미 좋아요된 게시글일 때
        <img width="511" height="236" alt="image" src="https://github.com/user-attachments/assets/ce4c3b00-eef4-488d-a541-9e609adbbd97" />


- 삭제
    - 정상적인 삭제
        <img width="511" height="272" alt="image" src="https://github.com/user-attachments/assets/1f8addff-d6c8-4572-8419-66234fc7851f" />


    - 좋아요 없을 때
        <img width="558" height="240" alt="image" src="https://github.com/user-attachments/assets/627ffa99-5233-4cfd-865f-7fdeffb6c7aa" />
