### PR TITLE
[refactor] 게시글 전체 조회 시 좋아요 여부와 PostStat 관련 성능 개선

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -2,6 +2,7 @@ package kakao_tech_bootcamp.community.controller;
 
 import kakao_tech_bootcamp.community.common.ApiResponse;
 import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
+import kakao_tech_bootcamp.community.dto.PostAllResponseDto;
 import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
 import kakao_tech_bootcamp.community.dto.PostResponseDto;
 import kakao_tech_bootcamp.community.dto.PostUpdateRequestDto;
@@ -31,10 +32,10 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<Map<String, List<PostResponseDto>>>> findPosts(@CurrentMember AuthInfo authInfo,
-                                                 @RequestParam(value = "lastPostId", required = false) Integer lastPostId,
-                                                 @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
-        List<PostResponseDto> posts = postService.findPosts(authInfo.getId(), lastPostId, limit);
+    public ResponseEntity<ApiResponse<Map<String, List<PostAllResponseDto>>>> findPosts(@CurrentMember AuthInfo authInfo,
+                                                                                        @RequestParam(value = "lastPostId", required = false) Integer lastPostId,
+                                                                                        @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+        List<PostAllResponseDto> posts = postService.findPosts(authInfo.getId(), lastPostId, limit);
         return ResponseEntity.ok(new ApiResponse<>("ok", Map.of("posts", posts)));
     }
 

--- a/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
@@ -1,22 +1,21 @@
 package kakao_tech_bootcamp.community.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import kakao_tech_bootcamp.community.entity.Image;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class ImageReferenceDto {
     private Integer id;
     private String objectKey;
 
-    public static ImageReferenceDto of(Image image) {
-        return image != null ? new ImageReferenceDto(image.getId(), image.getObjectKey()) : null;
+    @QueryProjection
+    public ImageReferenceDto(Integer id, String objectKey) {
+        this.id = id;
+        this.objectKey = objectKey;
     }
 
-    public static ImageReferenceDto of(Integer id, String objectKey) {
-        return id != null && objectKey != null ? new ImageReferenceDto(id, objectKey) : null;
+    public static ImageReferenceDto of(Image image) {
+        return image != null ? new ImageReferenceDto(image.getId(), image.getObjectKey()) : null;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
@@ -15,4 +15,8 @@ public class ImageReferenceDto {
     public static ImageReferenceDto of(Image image) {
         return image != null ? new ImageReferenceDto(image.getId(), image.getObjectKey()) : new ImageReferenceDto();
     }
+
+    public static ImageReferenceDto of(Integer id, String objectKey) {
+        return new ImageReferenceDto(id, objectKey);
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/ImageReferenceDto.java
@@ -13,10 +13,10 @@ public class ImageReferenceDto {
     private String objectKey;
 
     public static ImageReferenceDto of(Image image) {
-        return image != null ? new ImageReferenceDto(image.getId(), image.getObjectKey()) : new ImageReferenceDto();
+        return image != null ? new ImageReferenceDto(image.getId(), image.getObjectKey()) : null;
     }
 
     public static ImageReferenceDto of(Integer id, String objectKey) {
-        return new ImageReferenceDto(id, objectKey);
+        return id != null && objectKey != null ? new ImageReferenceDto(id, objectKey) : null;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/ImageResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/ImageResponseDto.java
@@ -1,14 +1,20 @@
 package kakao_tech_bootcamp.community.dto;
 
+import kakao_tech_bootcamp.community.entity.Image;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter @Setter
+@Getter
+@AllArgsConstructor
 @NoArgsConstructor
 public class ImageResponseDto {
     private Integer id;
     private String url; // presigned PUT URL과 CloudFront GET URL 자리
     private String objectKey;
     private String filename;
+
+    public static ImageResponseDto of(Image image) {
+        return new ImageResponseDto(image.getId(), null, image.getObjectKey(), image.getFilename());
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
@@ -13,4 +13,8 @@ public class MemberReferenceDto {
     public static MemberReferenceDto of(Member member) {
         return new MemberReferenceDto(member.getNickname(), ImageReferenceDto.of(member.getImage()));
     }
+
+    public static MemberReferenceDto of(String nickname, Integer imageId, String imageObjectKey) {
+        return new MemberReferenceDto(nickname, ImageReferenceDto.of(imageId, imageObjectKey));
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
@@ -1,20 +1,26 @@
 package kakao_tech_bootcamp.community.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import kakao_tech_bootcamp.community.entity.Member;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class MemberReferenceDto {
     private String nickname;
     private ImageReferenceDto image;
 
-    public static MemberReferenceDto of(Member member) {
-        return new MemberReferenceDto(member.getNickname(), ImageReferenceDto.of(member.getImage()));
+    @QueryProjection
+    public MemberReferenceDto(String nickname, ImageReferenceDto image) {
+        this.nickname = nickname;
+        /*
+        게시글 전체 조회 QueryDSL에서 게시글 이미지가 없을 때도 무조건 ImageReferenceDto를 new 하기 때문에
+        image: {id: null, objectKey: null}로 반환됨
+        따라서 직접 image.getId() == null 여부를 확인해 이미지가 없다면 image: null로 반환되도록 처리함
+         */
+        this.image = image == null || image.getId() == null ? null : image;
     }
 
-    public static MemberReferenceDto of(String nickname, Integer imageId, String imageObjectKey) {
-        return new MemberReferenceDto(nickname, ImageReferenceDto.of(imageId, imageObjectKey));
+    public static MemberReferenceDto of(Member member) {
+        return new MemberReferenceDto(member.getNickname(), ImageReferenceDto.of(member.getImage()));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/PostAllResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/PostAllResponseDto.java
@@ -1,0 +1,37 @@
+package kakao_tech_bootcamp.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostAllResponseDto {
+    private Integer id;
+    private String title;
+    private LocalDateTime createdAt;
+    private MemberReferenceDto member;
+    private boolean isLiked;
+    private int viewCount;
+    private int likeCount;
+    private int commentCount;
+
+    public static PostAllResponseDto of(Object[] row) {
+        Integer id = ((Number) row[0]).intValue();
+        String title = (String) row[1];
+        LocalDateTime createdAt = ((Timestamp) row[2]).toLocalDateTime();
+        String memberNickname = (String) row[3];
+        Integer memberImageId = row[4] != null ? ((Number) row[4]).intValue() : null;
+        String memberImageObjectKey = (String) row[5];
+        boolean isLiked = ((Number) row[6]).longValue() == 1L;
+        int viewCount = ((Number) row[7]).intValue();
+        int likeCount = ((Number) row[8]).intValue();
+        int commentCount = ((Number) row[9]).intValue();
+
+        MemberReferenceDto member = MemberReferenceDto.of(memberNickname, memberImageId, memberImageObjectKey);
+
+        return new PostAllResponseDto(id, title, createdAt, member, isLiked, viewCount, likeCount, commentCount);
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/PostAllResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/PostAllResponseDto.java
@@ -1,13 +1,11 @@
 package kakao_tech_bootcamp.community.dto;
 
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 public class PostAllResponseDto {
     private Integer id;
     private String title;
@@ -18,20 +16,24 @@ public class PostAllResponseDto {
     private int likeCount;
     private int commentCount;
 
-    public static PostAllResponseDto of(Object[] row) {
-        Integer id = ((Number) row[0]).intValue();
-        String title = (String) row[1];
-        LocalDateTime createdAt = ((Timestamp) row[2]).toLocalDateTime();
-        String memberNickname = (String) row[3];
-        Integer memberImageId = row[4] != null ? ((Number) row[4]).intValue() : null;
-        String memberImageObjectKey = (String) row[5];
-        boolean isLiked = ((Number) row[6]).longValue() == 1L;
-        int viewCount = ((Number) row[7]).intValue();
-        int likeCount = ((Number) row[8]).intValue();
-        int commentCount = ((Number) row[9]).intValue();
-
-        MemberReferenceDto member = MemberReferenceDto.of(memberNickname, memberImageId, memberImageObjectKey);
-
-        return new PostAllResponseDto(id, title, createdAt, member, isLiked, viewCount, likeCount, commentCount);
+    @QueryProjection
+    public PostAllResponseDto(
+            Integer id,
+            String title,
+            LocalDateTime createdAt,
+            MemberReferenceDto member,
+            boolean isLiked,
+            Integer viewCount,
+            Integer likeCount,
+            Integer commentCount
+    ) {
+        this.id = id;
+        this.title = title;
+        this.createdAt = createdAt;
+        this.member = member;
+        this.isLiked = isLiked;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Image.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Image.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,8 +11,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "image")
-@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class Image {
@@ -40,5 +39,9 @@ public class Image {
         this.filename = filename;
         this.objectKey = objectKey;
         this.status = status;
+    }
+
+    public void changeStatus(ImageStatus imageStatus) {
+        this.status = imageStatus;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Member.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Member.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,8 +11,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "member")
-@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class Member {
@@ -46,6 +45,18 @@ public class Member {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+        this.image = image;
+    }
+
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void changeImage(Image image) {
         this.image = image;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/entity/Member.java
+++ b/src/main/java/kakao_tech_bootcamp/community/entity/Member.java
@@ -24,7 +24,7 @@ public class Member {
     @Column(length = 50, nullable = false, unique = true)
     private String email;
 
-    @Column(length = 64, nullable = false)
+    @Column(length = 255, nullable = false)
     private String password;
 
     @Column(length = 10, nullable = false, unique = true)

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
@@ -2,32 +2,11 @@ package kakao_tech_bootcamp.community.repository;
 
 import kakao_tech_bootcamp.community.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Integer>, PostRepositoryCustom {
     Optional<Post> findByIdAndIsDeletedFalse(Integer postId);
-
-    @Query(value = """
-            SELECT
-            	p.id, p.title, p.created_at,
-            	m.nickname AS member_nickname, i.id AS member_image_id, i.object_key AS member_image_object_key,
-            	EXISTS (SELECT 1 FROM member_post_like WHERE post_id = p.id AND member_id = :memberId) AS is_liked,
-            	ps.view_count, ps.like_count, ps.comment_count
-            FROM post p
-            	JOIN member m ON m.id = p.member_id
-            	JOIN post_stat ps ON ps.post_id = p.id
-            	LEFT JOIN image i ON i.id = m.image_id
-            WHERE p.is_deleted = false AND (:lastPostId IS NULL OR p.id < :lastPostId)
-            ORDER BY p.id DESC
-            LIMIT :limit;
-            """, nativeQuery = true)
-    List<Object[]> findAllIdLessThanCustom(@Param("memberId") Integer memberId,
-                                           @Param("lastPostId") Integer lastPostId,
-                                           @Param("limit") Integer limit);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepository.java
@@ -1,9 +1,9 @@
 package kakao_tech_bootcamp.community.repository;
 
 import kakao_tech_bootcamp.community.entity.Post;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,9 +13,21 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Integer>, PostRepositoryCustom {
     Optional<Post> findByIdAndIsDeletedFalse(Integer postId);
 
-    @EntityGraph(attributePaths = {"member", "member.image", "image"})
-    List<Post> findByIsDeletedFalseOrderByIdDesc(Pageable pageable);
-
-    @EntityGraph(attributePaths = {"member", "member.image", "image"})
-    List<Post> findByIsDeletedFalseAndIdLessThanOrderByIdDesc(Integer lastPostId, Pageable pageable);
+    @Query(value = """
+            SELECT
+            	p.id, p.title, p.created_at,
+            	m.nickname AS member_nickname, i.id AS member_image_id, i.object_key AS member_image_object_key,
+            	EXISTS (SELECT 1 FROM member_post_like WHERE post_id = p.id AND member_id = :memberId) AS is_liked,
+            	ps.view_count, ps.like_count, ps.comment_count
+            FROM post p
+            	JOIN member m ON m.id = p.member_id
+            	JOIN post_stat ps ON ps.post_id = p.id
+            	LEFT JOIN image i ON i.id = m.image_id
+            WHERE p.is_deleted = false AND (:lastPostId IS NULL OR p.id < :lastPostId)
+            ORDER BY p.id DESC
+            LIMIT :limit;
+            """, nativeQuery = true)
+    List<Object[]> findAllIdLessThanCustom(@Param("memberId") Integer memberId,
+                                           @Param("lastPostId") Integer lastPostId,
+                                           @Param("limit") Integer limit);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustom.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustom.java
@@ -1,7 +1,11 @@
 package kakao_tech_bootcamp.community.repository;
 
+import kakao_tech_bootcamp.community.dto.PostAllResponseDto;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PostRepositoryCustom {
+    List<PostAllResponseDto> findAllIdLessThanCustom(Integer memberId, Integer lastPostId, Integer limit);
     long deleteAllByIsDeletedTrueAndDynamicFilters(Integer memberId, LocalDateTime before, LocalDateTime after);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustomImpl.java
@@ -1,16 +1,68 @@
 package kakao_tech_bootcamp.community.repository;
 
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import kakao_tech_bootcamp.community.dto.PostAllResponseDto;
+import kakao_tech_bootcamp.community.dto.QPostAllResponseDto;
+import kakao_tech_bootcamp.community.dto.QMemberReferenceDto;
+import kakao_tech_bootcamp.community.dto.QImageReferenceDto;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import static kakao_tech_bootcamp.community.entity.QImage.image;
+import static kakao_tech_bootcamp.community.entity.QMember.member;
+import static kakao_tech_bootcamp.community.entity.QMemberPostLike.memberPostLike;
 import static kakao_tech_bootcamp.community.entity.QPost.post;
+import static kakao_tech_bootcamp.community.entity.QPostStat.postStat;
 
 @RequiredArgsConstructor
 public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<PostAllResponseDto> findAllIdLessThanCustom(Integer memberId, Integer lastPostId, Integer limit) {
+        Expression<Boolean> isLikedExpression = JPAExpressions
+                .selectOne()
+                .from(memberPostLike)
+                .where(memberPostLike.memberPostLikeId.postId.eq(post.id)
+                        .and(memberPostLike.memberPostLikeId.memberId.eq(memberId)))
+                .exists();
+
+        JPAQuery<PostAllResponseDto> query = jpaQueryFactory
+                .select(
+                        new QPostAllResponseDto(
+                                post.id,
+                                post.title,
+                                post.createdAt,
+                                new QMemberReferenceDto(
+                                        member.nickname,
+                                        new QImageReferenceDto(
+                                                image.id,
+                                                image.objectKey
+                                        )
+                                ),
+                                isLikedExpression,
+                                postStat.viewCount,
+                                postStat.likeCount,
+                                postStat.commentCount
+                        )
+                )
+                .from(post)
+                .join(member).on(member.id.eq(post.member.id))
+                .join(postStat).on(postStat.postId.eq(post.id))
+                .leftJoin(image).on(image.id.eq(member.image.id))
+                .where(post.isDeleted.eq(false)
+                        .and(lastPostId == null ? null : post.id.lt(lastPostId)))
+                .orderBy(post.id.desc())
+                .limit(limit);
+
+        return query.fetch();
+    }
 
     @Override
     public long deleteAllByIsDeletedTrueAndDynamicFilters(Integer memberId, LocalDateTime before, LocalDateTime after) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
@@ -47,12 +47,7 @@ public class ImageService {
         destination.getParentFile().mkdirs();
         file.transferTo(destination);
 
-        ImageResponseDto imageResponseDto = new ImageResponseDto();
-        imageResponseDto.setId(saveImage.getId());
-        imageResponseDto.setObjectKey(objectKey);
-        imageResponseDto.setFilename(filename);
-
-        return imageResponseDto;
+        return ImageResponseDto.of(image);
     }
 
     public Image modifyImageStatusById(Integer imageId, ImageStatus imageStatus) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/ImageService.java
@@ -58,7 +58,7 @@ public class ImageService {
     public Image modifyImageStatusById(Integer imageId, ImageStatus imageStatus) {
         Image image = imageRepository.findById(imageId)
                 .orElseThrow(() -> new NotFoundException("이미지를 찾을 수 없습니다"));
-        image.setStatus(imageStatus);
+        image.changeStatus(imageStatus);
         // TODO: 엔티티 말고 dto를 반환할 방법?
         return image;
     }

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -82,7 +82,7 @@ public class MemberService {
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
         if (dto.getNickname() != null) {
-            member.setNickname(dto.getNickname());
+            member.changeNickname(dto.getNickname());
         }
 
         if (dto.getPassword() != null) {
@@ -90,7 +90,7 @@ public class MemberService {
                 throw new BadRequestException("비밀번호가 일치하지 않습니다");
             }
 
-            member.setPassword(passwordEncoder.encode(dto.getPassword()));
+            member.changePassword(passwordEncoder.encode(dto.getPassword()));
         }
 
         /*
@@ -100,7 +100,7 @@ public class MemberService {
          */
         if (dto.getImageDeleted() && dto.getImage() == null && member.getImage() != null) {
             Image previousImage = member.getImage();
-            member.setImage(null);
+            member.changeImage(null);
             imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
         }
 
@@ -108,7 +108,7 @@ public class MemberService {
             Image previousImage = member.getImage();
 
             Image currentImage = imageService.modifyImageStatusById(dto.getImage().getId(), ImageStatus.ACTIVE);
-            member.setImage(currentImage);
+            member.changeImage(currentImage);
 
             /*
              removeImage()에는 데이터베이스뿐만 아니라 물리적인 이미지 파일 삭제까지 포함되어 있음

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -2,6 +2,7 @@ package kakao_tech_bootcamp.community.service;
 
 import kakao_tech_bootcamp.community.common.exceptions.ForbiddenException;
 import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
+import kakao_tech_bootcamp.community.dto.PostAllResponseDto;
 import kakao_tech_bootcamp.community.dto.PostCreateRequestDto;
 import kakao_tech_bootcamp.community.dto.PostResponseDto;
 import kakao_tech_bootcamp.community.dto.PostUpdateRequestDto;
@@ -9,8 +10,6 @@ import kakao_tech_bootcamp.community.entity.*;
 import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,20 +58,9 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponseDto> findPosts(Integer currentMemberId, Integer lastPostId, Integer limit) {
-        Pageable pageable = PageRequest.of(0, limit);
-        List<Post> posts = lastPostId == null
-                ? postRepository.findByIsDeletedFalseOrderByIdDesc(pageable)
-                : postRepository.findByIsDeletedFalseAndIdLessThanOrderByIdDesc(lastPostId, pageable);
-
-        return posts.stream().map(
-                x -> PostResponseDto.of(
-                        x,
-                        memberPostLikeRepository.existsByMemberPostLikeIdPostIdAndMemberPostLikeIdMemberId(x.getId(), currentMemberId),
-                        postStatService.findPostStat(x).orElseGet(
-                                () -> postStatService.savePostStatInitializedByCount(x)
-                        )))
-                .toList();
+    public List<PostAllResponseDto> findPosts(Integer currentMemberId, Integer lastPostId, Integer limit) {
+        return postRepository.findAllIdLessThanCustom(currentMemberId, lastPostId, limit)
+                .stream().map(PostAllResponseDto::of).toList();
     }
 
     public void modifyPost(Integer currentMemberId, Integer postId, PostUpdateRequestDto dto) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -59,8 +59,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public List<PostAllResponseDto> findPosts(Integer currentMemberId, Integer lastPostId, Integer limit) {
-        return postRepository.findAllIdLessThanCustom(currentMemberId, lastPostId, limit)
-                .stream().map(PostAllResponseDto::of).toList();
+        return postRepository.findAllIdLessThanCustom(currentMemberId, lastPostId, limit);
     }
 
     public void modifyPost(Integer currentMemberId, Integer postId, PostUpdateRequestDto dto) {


### PR DESCRIPTION
## 리팩토링 이유
- 기존 게시글 전체 조회 시 N + 1 문제 발생
    - `@EntityGraph`로 게시글 전체 조회하여 게시글 이미지, 게시글 작성자, 게시글 작성자의 이미지는 한꺼번에 조인해 N + 1 문제 해결
    - 그러나 반환 시 게시글마다 MemberPostLike에서 좋아요 여부 조회와 PostStat 조회를 조회해 N + 1 발생
        ```java
        return posts.stream().map(
                x -> PostResponseDto.of(
                        x,
                        memberPostLikeRepository.좋아요존재여부(x.getId(), currentMemberId),
                        postStatService.findPostStat(x)
                 ))
                .toList();
        ```
- 따라서 게시글 정보와 좋아요 여부, 게시글 통계성 데이터까지 전부 한꺼번에 하나의 쿼리로 가져오도록 리팩토링하기로 결정

<br>
<br>
<br>

## 작업 내용
- 게시글 전체 조회용 PostAllResponseDto 생성
    - 게시글 상세 조회와 달리 게시글의 이미지 정보를 반환하지 않음
- QueryDSL을 사용한 게시글 전체 조회용 메서드 생성
    - 일부 dto에서 `@AllArgsConstructor` 대신 직접 생성자 작성 및 `@QueryProjection` 사용하도록 수정
        - PostAllResponseDto와 그 안에서 사용하는 MemberReferenceDto, ImageReferenceDto

<br>
<br>
<br>

## 고민 내용
### Native Query vs QueryDSL
- `@Query("네이티브 쿼리", nativeQuery=true)`하면 간단하지만 문자열 기반이라 유지보수와 안정성이 QueryDSL에 비해 떨어짐
- `결론` QueryDSL 사용

<br>
<br>
<br>

## 화면 캡처
<img width="796" height="762" alt="image" src="https://github.com/user-attachments/assets/d56da00d-beac-4901-850d-80af71b3d937" />