### PR TITLE
[chore] Member, Post의 생성, 수정 응답 바디 데이터 추가

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -26,7 +26,7 @@ public class CommentController {
                                                    @PathVariable Integer postId,
                                                    @RequestBody @Validated CommentRequestDto commentRequestDto) {
         CommentResponseDto comment = commentService.saveComment(authInfo.getId(), postId, commentRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("comment_create_success", Map.of("comment", comment)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("create_success", Map.of("comment", comment)));
     }
 
     @GetMapping
@@ -42,8 +42,8 @@ public class CommentController {
                                                      @PathVariable("postId") Integer postId,
                                                      @PathVariable("commentId") Integer commentId,
                                                      @RequestBody @Validated CommentRequestDto commentRequestDto) {
-        Map<String, Object> modifiedFiles = commentService.modifyComment(authInfo.getId(), postId, commentId, commentRequestDto);
-        return ResponseEntity.ok(new ApiResponse<>("ok", modifiedFiles));
+        Map<String, Object> changes = commentService.modifyComment(authInfo.getId(), postId, commentId, commentRequestDto);
+        return ResponseEntity.ok(new ApiResponse<>("modify_success", changes));
     }
 
     @DeleteMapping("/{commentId}")

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -36,9 +36,9 @@ public class MemberController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Void>> saveMember(@RequestBody @Validated MemberCreateRequestDto memberCreateRequestDto) {
-        memberService.saveMember(memberCreateRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("register_success", null));
+    public ResponseEntity<ApiResponse<Map<String, MemberResponseDto>>> saveMember(@RequestBody @Validated MemberCreateRequestDto memberCreateRequestDto) {
+        MemberResponseDto member = memberService.saveMember(memberCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("create_success", Map.of("member", member)));
     }
 
     @GetMapping("/{memberId}")
@@ -48,11 +48,11 @@ public class MemberController {
     }
 
     @PatchMapping("/{memberId}")
-    public ResponseEntity<Void> modifyMember(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, Object>>> modifyMember(@CurrentMember AuthInfo authInfo,
                                        @PathVariable Integer memberId,
                                        @RequestBody @Validated MemberUpdateRequestDto updateMemberRequestDto) {
-        memberService.modifyMember(authInfo.getId(), memberId, updateMemberRequestDto);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        Map<String, Object> changes = memberService.modifyMember(authInfo.getId(), memberId, updateMemberRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("modify_success", changes));
     }
 
     @DeleteMapping("/{memberId}")

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberPostLikeController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberPostLikeController.java
@@ -22,12 +22,12 @@ public class MemberPostLikeController {
         int likeCount = likeService.saveLike(authInfo.getId(), postId);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(new ApiResponse<>("like_create_success", Map.of("likeCount", likeCount)));
+                .body(new ApiResponse<>("create_success", Map.of("likeCount", likeCount)));
     }
 
     @DeleteMapping
     public ResponseEntity<ApiResponse<Map<String, Integer>>> removeLike(@CurrentMember AuthInfo authInfo, @PathVariable Integer postId) {
         int likeCount = likeService.removeLike(authInfo.getId(), postId);
-        return ResponseEntity.ok(new ApiResponse<>("like_delete_success", Map.of("likeCount", likeCount)));
+        return ResponseEntity.ok(new ApiResponse<>("delete_success", Map.of("likeCount", likeCount)));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/PostController.java
@@ -25,10 +25,10 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Void>> savePost(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, PostResponseDto>>> savePost(@CurrentMember AuthInfo authInfo,
                                                 @RequestBody PostCreateRequestDto postCreateRequestDto) {
-        postService.savePost(authInfo.getId(), postCreateRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("post_create_success", null));
+        PostResponseDto post = postService.savePost(authInfo.getId(), postCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("create_success", Map.of("post", post)));
     }
 
     @GetMapping
@@ -46,11 +46,11 @@ public class PostController {
     }
 
     @PatchMapping("/{postId}")
-    public ResponseEntity<Void> modifyPost(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, Object>>> modifyPost(@CurrentMember AuthInfo authInfo,
                                                   @PathVariable Integer postId,
                                                   @RequestBody @Validated PostUpdateRequestDto postUpdateRequestDto) {
-        postService.modifyPost(authInfo.getId(), postId, postUpdateRequestDto);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        Map<String, Object> changes = postService.modifyPost(authInfo.getId(), postId, postUpdateRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("modify_success", changes));
     }
 
     @DeleteMapping

--- a/src/main/java/kakao_tech_bootcamp/community/dto/PostResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/PostResponseDto.java
@@ -28,4 +28,10 @@ public class PostResponseDto {
                 post.getCreatedAt(), isLiked,
                 postStat.getViewCount(), postStat.getLikeCount(), postStat.getCommentCount());
     }
+
+    public static PostResponseDto of(Post post) {
+        return new PostResponseDto(post.getId(), post.getTitle(), post.getContent(),
+                MemberReferenceDto.of(post.getMember()), ImageReferenceDto.of(post.getImage()),
+                post.getCreatedAt(), false, 0, 0, 0);
+    }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -14,6 +14,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 @Service
@@ -44,7 +46,7 @@ public class MemberService {
         }
     }
 
-    public void saveMember(MemberCreateRequestDto dto) {
+    public MemberResponseDto saveMember(MemberCreateRequestDto dto) {
         if (!dto.getPassword().equals(dto.getConfirmedPassword())) {
             throw new BadRequestException("비밀번호가 일치하지 않습니다");
         }
@@ -64,7 +66,7 @@ public class MemberService {
         String encoded = passwordEncoder.encode(dto.getPassword());
         Member member = new Member(dto.getEmail(), encoded, dto.getNickname(), image);
 
-        memberRepository.save(member);
+        return MemberResponseDto.of(memberRepository.save(member));
     }
 
     @Transactional(readOnly = true)
@@ -73,7 +75,7 @@ public class MemberService {
         return MemberResponseDto.of(member);
     }
 
-    public void modifyMember(Integer currentMemberId, Integer id, MemberUpdateRequestDto dto) {
+    public Map<String, Object> modifyMember(Integer currentMemberId, Integer id, MemberUpdateRequestDto dto) {
         if (!Objects.equals(currentMemberId, id)) {
             throw new ForbiddenException("회원 본인 정보에 대해서만 수정할 수 있습니다");
         }
@@ -81,9 +83,7 @@ public class MemberService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
-        if (dto.getNickname() != null) {
-            member.changeNickname(dto.getNickname());
-        }
+        Map<String, Object> changes = new HashMap<>();
 
         if (dto.getPassword() != null) {
             if (!dto.getPassword().equals(dto.getConfirmedPassword())) {
@@ -91,6 +91,12 @@ public class MemberService {
             }
 
             member.changePassword(passwordEncoder.encode(dto.getPassword()));
+            changes.put("passwordChanged", true);
+        }
+
+        if (dto.getNickname() != null) {
+            member.changeNickname(dto.getNickname());
+            changes.put("nickname", member.getNickname());
         }
 
         /*
@@ -102,6 +108,8 @@ public class MemberService {
             Image previousImage = member.getImage();
             member.changeImage(null);
             imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
+
+            changes.put("image", member.getImage());
         }
 
         if (dto.getImage() != null) {
@@ -118,7 +126,11 @@ public class MemberService {
             if (previousImage != null) {
                 imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
             }
+
+            changes.put("image", ImageResponseDto.of(member.getImage()));
         }
+
+        return changes;
     }
 
     public void removeMember(Integer currentMemberId, Integer id) {

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostService.java
@@ -9,16 +9,16 @@ import kakao_tech_bootcamp.community.dto.PostUpdateRequestDto;
 import kakao_tech_bootcamp.community.entity.*;
 import kakao_tech_bootcamp.community.repository.*;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
-@Log4j2
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -29,7 +29,7 @@ public class PostService {
     private final ImageService imageService;
     private final PostStatService postStatService;
 
-    public void savePost(Integer currentMemberId, PostCreateRequestDto dto) {
+    public PostResponseDto savePost(Integer currentMemberId, PostCreateRequestDto dto) {
         Member member = memberRepository.findById(currentMemberId)
                 .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
@@ -38,9 +38,9 @@ public class PostService {
                 : null;
 
         Post savePost = postRepository.save(new Post(dto.getTitle(), dto.getContent(), member, image)); // 바로 flush 해야 참조 무결성 유지
-        log.info("PostService에서 post save 완료");
         postStatService.savePostStat(savePost); // 지연 쓰기로 인해 log 모두 출력 후 post_stat insert (flush) 실행
-        log.info("PostService에서 PostStat save 완료");
+
+        return PostResponseDto.of(savePost);
     }
 
     @Transactional(readOnly = true)
@@ -62,24 +62,29 @@ public class PostService {
         return postRepository.findAllIdLessThanCustom(currentMemberId, lastPostId, limit);
     }
 
-    public void modifyPost(Integer currentMemberId, Integer postId, PostUpdateRequestDto dto) {
+    public Map<String, Object> modifyPost(Integer currentMemberId, Integer postId, PostUpdateRequestDto dto) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
 
         if (!Objects.equals(post.getMember().getId(), currentMemberId)) {
             throw new ForbiddenException("게시글을 작성한 회원만 수정할 수 있습니다");
         }
 
+        Map<String, Object> changes = new HashMap<>();
+
         if (dto.getPostDeleted()) {
             post.markDeleted(); // 관련 이미지 상태는 여전히 ACTIVE (배치 프로그램에 의해 삭제되지 않도록)
-            return; // soft delete 요청 시 그 외 게시글 수정 무시
+            changes.put("postDeleted", true);
+            return changes; // soft delete 요청 시 그 외 게시글 수정 무시
         }
 
         if (dto.getTitle() != null) {
             post.changeTitle(dto.getTitle());
+            changes.put("title", post.getTitle());
         }
 
         if (dto.getContent() != null) {
             post.changeContent(dto.getContent());
+            changes.put("content", post.getContent());
         }
 
         /*
@@ -90,6 +95,8 @@ public class PostService {
             Image previousImage = post.getImage();
             post.changeImage(null);
             imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
+
+            changes.put("image", post.getImage());
         }
 
         if (dto.getImage() != null) {
@@ -101,7 +108,11 @@ public class PostService {
             if (previousImage != null) {
                 imageService.removeImage(previousImage.getId(), previousImage.getObjectKey());
             }
+
+            changes.put("image", post.getImage());
         }
+
+        return changes;
     }
 
     public long removePosts(LocalDate before, LocalDate after, Integer memberId) {


### PR DESCRIPTION
## 작업 내용
- 회원/게시글 생성 시 생성된 회원/게시글 데이터 반환
- 회원/게시글 수정 시 수정된 필드 반환

<br>
<br>
<br>

## 화면 캡처
- 회원 생성
    <img width="539" height="381" alt="image" src="https://github.com/user-attachments/assets/a780fdea-ec56-4d79-8f52-885aaf61e4aa" />

- 회원 수정
    <img width="557" height="414" alt="image" src="https://github.com/user-attachments/assets/d59d8962-23a3-4287-bfe5-bb3fa34dcaad" />

- 게시글 생성
    <img width="561" height="670" alt="image" src="https://github.com/user-attachments/assets/0ad54a74-4bb3-45ee-944f-74ef04256e8f" />

- 게시글 수정
    <img width="561" height="426" alt="image" src="https://github.com/user-attachments/assets/95177004-3a4e-44d3-8046-0decae6e28f6" />
