### PR TITLE
[fix] 프론트 서버 환경에 맞춰 일부 수정

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/common/ApiResponse.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/ApiResponse.java
@@ -6,46 +6,47 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ApiResponse<T> {
+    private boolean success;
     private String message;
     private T data;
 
     public static <T> ApiResponse<T> success()  {
-        return new ApiResponse<>(ApiMessage.SUCCESS.getMessage(), null);
+        return new ApiResponse<>(true, ApiMessage.SUCCESS.getMessage(), null);
     }
 
     public static <T> ApiResponse<T> success(T data)  {
-        return new ApiResponse<>(ApiMessage.SUCCESS.getMessage(), data);
+        return new ApiResponse<>(true, ApiMessage.SUCCESS.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> created(T data)  {
-        return new ApiResponse<>(ApiMessage.CREATED.getMessage(), data);
+        return new ApiResponse<>(true, ApiMessage.CREATED.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> modified(T data)  {
-        return new ApiResponse<>(ApiMessage.MODIFIED.getMessage(), data);
+        return new ApiResponse<>(true, ApiMessage.MODIFIED.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> removed(T data)  {
-        return new ApiResponse<>(ApiMessage.REMOVED.getMessage(), data);
+        return new ApiResponse<>(true, ApiMessage.REMOVED.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> badRequest(T data) {
-        return new ApiResponse<>(ApiMessage.BAD_REQUEST.getMessage(), data);
+        return new ApiResponse<>(false, ApiMessage.BAD_REQUEST.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> unauthorized(T data) {
-        return new ApiResponse<>(ApiMessage.UNAUTHORIZED.getMessage(), data);
+        return new ApiResponse<>(false, ApiMessage.UNAUTHORIZED.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> forbidden(T data) {
-        return new ApiResponse<>(ApiMessage.FORBIDDEN.getMessage(), data);
+        return new ApiResponse<>(false, ApiMessage.FORBIDDEN.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> notFound(T data) {
-        return new ApiResponse<>(ApiMessage.NOT_FOUND.getMessage(), data);
+        return new ApiResponse<>(false, ApiMessage.NOT_FOUND.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> conflict(T data) {
-        return new ApiResponse<>(ApiMessage.CONFLICT.getMessage(), data);
+        return new ApiResponse<>(false, ApiMessage.CONFLICT.getMessage(), data);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
@@ -34,6 +34,10 @@ public class AuthInterceptor implements HandlerInterceptor {
         String uri = request.getRequestURI();
         String method = request.getMethod();
 
+        if ("OPTIONS".equals(method)) {
+            return true;
+        }
+
         if (PUBLIC_ENDPOINT.containsKey(uri) && PUBLIC_ENDPOINT.get(uri).equals(method)) {
             return true;
         }

--- a/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
+++ b/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
@@ -5,6 +5,7 @@ import kakao_tech_bootcamp.community.common.CurrentMemberResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -29,5 +30,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentMemberResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PATCH", "DELETE")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -24,6 +24,7 @@ public class AuthController {
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId)
                 .httpOnly(true)
                 .sameSite("None")
+                .secure(true)
                 .maxAge(60 * 60 * 24 * 7) // 일주일
                 .build();
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController {
         String sessionId = authStrategy.issue(authRequestDto);
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId)
                 .httpOnly(true)
-                .sameSite("Strict")
+                .sameSite("None")
                 .maxAge(60 * 60 * 24 * 7) // 일주일
                 .build();
         return ResponseEntity.status(HttpStatus.CREATED)


### PR DESCRIPTION
## 작업 내용

- 로그인 시 쿠키 설정 변경
    - sameStie : None으로 설정
    - secure : true로 설정
- CORS 정책에서 프론트엔드 서버 오리진 허용하도록 등록
- ApiResponse에 success 필드 추가