### PR TITLE
[fix] 프론트 서버 환경에 맞춰 일부 수정2

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/AuthInterceptor.java
@@ -38,6 +38,10 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
+        if (uri.startsWith("/s3/members")) {
+            return true;
+        }
+
         if (PUBLIC_ENDPOINT.containsKey(uri) && PUBLIC_ENDPOINT.get(uri).equals(method)) {
             return true;
         }

--- a/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
+++ b/src/main/java/kakao_tech_bootcamp/community/config/WebConfig.java
@@ -3,16 +3,22 @@ package kakao_tech_bootcamp.community.config;
 import kakao_tech_bootcamp.community.common.AuthInterceptor;
 import kakao_tech_bootcamp.community.common.CurrentMemberResolver;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.io.File;
 import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    @Value("${storage.domain}")
+    private String domain;
+
     private final AuthInterceptor authInterceptor;
     private final CurrentMemberResolver currentMemberResolver;
 
@@ -38,5 +44,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:3000")
                 .allowedMethods("GET", "POST", "PATCH", "DELETE")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler(File.separator + "s3" + File.separator + "**")
+                .addResourceLocations("file:" + domain);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -25,6 +25,7 @@ public class AuthController {
                 .httpOnly(true)
                 .sameSite("None")
                 .secure(true)
+                .path("/")
                 .maxAge(60 * 60 * 24 * 7) // 일주일
                 .build();
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -35,7 +36,15 @@ public class AuthController {
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> logout(@CookieValue("sid") String sessionId) {
         authStrategy.invalidate(sessionId);
-        ResponseCookie cookie = ResponseCookie.from("sid", sessionId).maxAge(0).build();
+
+        ResponseCookie cookie = ResponseCookie.from("sid", sessionId)
+                .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
+                .path("/")
+                .maxAge(0) // 일주일
+                .build();
+
         return ResponseEntity.status(HttpStatus.OK)
                 .header(SET_COOKIE, cookie.toString())
                 .body(ApiResponse.success());

--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -36,8 +36,8 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> logout(@CookieValue("sid") String sessionId) {
         authStrategy.invalidate(sessionId);
         ResponseCookie cookie = ResponseCookie.from("sid", sessionId).maxAge(0).build();
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        return ResponseEntity.status(HttpStatus.OK)
                 .header(SET_COOKIE, cookie.toString())
-                .build();
+                .body(ApiResponse.success());
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -22,11 +22,11 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Map<String, CommentResponseDto>>> saveComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, Object>>> saveComment(@CurrentMember AuthInfo authInfo,
                                                    @PathVariable Integer postId,
                                                    @RequestBody @Validated CommentRequestDto commentRequestDto) {
-        CommentResponseDto comment = commentService.saveComment(authInfo.getId(), postId, commentRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(Map.of("comment", comment)));
+        Map<String, Object> data = commentService.saveComment(authInfo.getId(), postId, commentRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(data));
     }
 
     @GetMapping
@@ -47,10 +47,10 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ApiResponse<Void>> removeComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Map<String, Integer>>> removeComment(@CurrentMember AuthInfo authInfo,
                                                      @PathVariable("postId") Integer postId,
                                                      @PathVariable("commentId") Integer commentId) {
-        commentService.removeComment(authInfo.getId(), postId, commentId);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success());
+        int commentCount = commentService.removeComment(authInfo.getId(), postId, commentId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(Map.of("commentCount", commentCount)));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/CommentController.java
@@ -47,10 +47,10 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<Void> removeComment(@CurrentMember AuthInfo authInfo,
+    public ResponseEntity<ApiResponse<Void>> removeComment(@CurrentMember AuthInfo authInfo,
                                                      @PathVariable("postId") Integer postId,
                                                      @PathVariable("commentId") Integer commentId) {
         commentService.removeComment(authInfo.getId(), postId, commentId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success());
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -4,19 +4,26 @@ import kakao_tech_bootcamp.community.common.ApiResponse;
 import kakao_tech_bootcamp.community.common.annotation.CurrentMember;
 import kakao_tech_bootcamp.community.dto.*;
 import kakao_tech_bootcamp.community.service.AuthInfo;
+import kakao_tech_bootcamp.community.service.AuthStrategy;
 import kakao_tech_bootcamp.community.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+@Log4j2
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
+    private final AuthStrategy authStrategy;
     private final MemberService memberService;
 
     @PostMapping("/availability/email")
@@ -52,8 +59,21 @@ public class MemberController {
     }
 
     @DeleteMapping("/{memberId}")
-    public ResponseEntity<ApiResponse<Void>> removeMember(@CurrentMember AuthInfo authInfo, @PathVariable Integer memberId) {
+    public ResponseEntity<ApiResponse<Void>> removeMember(@CookieValue("sid") String sessionId,
+                                                          @CurrentMember AuthInfo authInfo,
+                                                          @PathVariable Integer memberId) {
         memberService.removeMember(authInfo.getId(), memberId);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success());
+
+        ResponseCookie cookie = ResponseCookie.from("sid", sessionId)
+                .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
+                .path("/")
+                .maxAge(0) // 일주일
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(SET_COOKIE, cookie.toString())
+                .body(ApiResponse.success());
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -52,8 +52,8 @@ public class MemberController {
     }
 
     @DeleteMapping("/{memberId}")
-    public ResponseEntity<Void> removeMember(@CurrentMember AuthInfo authInfo, @PathVariable Integer memberId) {
+    public ResponseEntity<ApiResponse<Void>> removeMember(@CurrentMember AuthInfo authInfo, @PathVariable Integer memberId) {
         memberService.removeMember(authInfo.getId(), memberId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success());
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberReferenceDto.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 
 @Getter
 public class MemberReferenceDto {
+    private Integer id;
     private String nickname;
     private ImageReferenceDto image;
 
     @QueryProjection
-    public MemberReferenceDto(String nickname, ImageReferenceDto image) {
+    public MemberReferenceDto(Integer id, String nickname, ImageReferenceDto image) {
+        this.id = id;
         this.nickname = nickname;
         /*
         게시글 전체 조회 QueryDSL에서 게시글 이미지가 없을 때도 무조건 ImageReferenceDto를 new 하기 때문에
@@ -21,6 +23,6 @@ public class MemberReferenceDto {
     }
 
     public static MemberReferenceDto of(Member member) {
-        return new MemberReferenceDto(member.getNickname(), ImageReferenceDto.of(member.getImage()));
+        return new MemberReferenceDto(member.getId(), member.getNickname(), ImageReferenceDto.of(member.getImage()));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/PostRepositoryCustomImpl.java
@@ -40,6 +40,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                                 post.title,
                                 post.createdAt,
                                 new QMemberReferenceDto(
+                                        member.id,
                                         member.nickname,
                                         new QImageReferenceDto(
                                                 image.id,

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
@@ -51,6 +51,9 @@ public class AuthSessionStrategy implements AuthStrategy {
         String sessionId = UUID.randomUUID().toString();
         AuthInfo session = new AuthInfo(member.getId());
 
+        // NOTE: 프론트 서버에서 회원 정보를 알아내기 위해 memberId 추가
+        sessionId += "_" + member.getId();
+
         sessionRepository.save(sessionId, session);
 
         return sessionId;

--- a/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/CommentService.java
@@ -30,16 +30,16 @@ public class CommentService {
     private final MemberRepository memberRepository;
     private final PostStatService postStatService;
 
-    public CommentResponseDto saveComment(Integer currentMemberId, Integer postId, CommentRequestDto dto) {
+    public Map<String, Object> saveComment(Integer currentMemberId, Integer postId, CommentRequestDto dto) {
         Post post = postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
         Member member = memberRepository.findById(currentMemberId).orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
         Comment comment = commentRepository.save(new Comment(post, member, dto.getContent()));
 
         PostStat postStat = postStatService.findPostStat(post)
                 .orElseGet(() -> postStatService.savePostStatInitializedByCount(post));
-        postStatService.incrementCommentCount(postStat);
+        int commentCount = postStatService.incrementCommentCount(postStat);
 
-        return CommentResponseDto.of(comment);
+        return Map.of("comment", CommentResponseDto.of(comment), "commentCount", commentCount);
     }
 
     @Transactional(readOnly = true)
@@ -67,7 +67,7 @@ public class CommentService {
         return Map.of("content", comment.getContent());
     }
 
-    public void removeComment(Integer currentMemberId, Integer postId, Integer commentId) {
+    public int removeComment(Integer currentMemberId, Integer postId, Integer commentId) {
         Post post = postRepository.findByIdAndIsDeletedFalse(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다"));
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다"));
 
@@ -77,8 +77,10 @@ public class CommentService {
 
         PostStat postStat = postStatService.findPostStat(post)
                 .orElseGet(() -> postStatService.savePostStatInitializedByCount(post));
-        postStatService.decrementCommentCount(postStat);
+        int commentCount = postStatService.decrementCommentCount(postStat);
 
         commentRepository.delete(comment);
+
+        return commentCount;
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/PostStatService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/PostStatService.java
@@ -76,11 +76,13 @@ public class PostStatService {
         return postStat.getLikeCount() - 1;
     }
 
-    public void incrementCommentCount(PostStat postStat) {
+    public int incrementCommentCount(PostStat postStat) {
         postStatAsyncService.asyncIncrementCommentCount(postStat.getPostId());
+        return postStat.getCommentCount() + 1;
     }
 
-    public void decrementCommentCount(PostStat postStat) {
+    public int decrementCommentCount(PostStat postStat) {
         postStatAsyncService.asyncDecrementCommentCount(postStat.getPostId());
+        return postStat.getCommentCount() - 1;
     }
 }


### PR DESCRIPTION
## 작업 내용

- DELETE 요청에 대한 응답 상태 코드 수정
    - 기존: 204 (No Content)
    - 변경: 200 (Ok) + 응답 바디
    - 이유: 프론트 측에서 REST API 요청에 대한 응답을 처리하려면 모든 응답이 공통 구조를 이루는 것이 편리함

- 댓글 생성/삭제 후 commentCount 필드 함께 응답하도록 함
     - 프론트 측에서 임의로 commentCount - 1 하거나, 새로고침하는 것보다 서버에서 commentCount 필드를 내려주는 것이 효율적이고 프론트가 작업하기 편리함
     - 또한 좋아요 생성/삭제 시 likeCount 필드를 응답하고 있어 응답 메시지의 구조가 통일됨

- sid 쿠키 값 설정 시 회원 정보 추가
    > 임시 방편으로 곧 삭제 예정
    - 기존: UUID값 반환
    - 변경: UUID값_memberId
    - 이유: 프론트 측에서 현재 이 로그인한 회원이 누구인지 알아내기 위함
        - 그러나 곧 프론트의 로그인 확인 여부 방식이 바뀔 예정이므로 이 변경사항은 원래대로 되돌아갈 것

- MemberReferenceDto에 id 필드 추가
    - MemberReferenceDto는 게시글/댓글 작성자에 활용됨
    - 현재 로그인한 회원의 id와 게시글/댓글 작성자의 id가 동일한지 비교하기 위해 id 필드 추가

- 회원 탈퇴 시 곧 바로 로그인 인증 정보 파기 처리
    - 회원 정보 삭제만 진행해 회원 탈퇴 후에도 로그인 상태가 유지됐었음

- 클라이언트가 업로드한 이미지가 저장되는 s3/ 폴더 정적 서빙하도록 설정
    - 이미지 조회가 필요하기 때문