### PR TITLE
[feat] 인증 정보 검증 API 등록

### DIFF
--- a/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/AuthController.java
@@ -2,6 +2,7 @@ package kakao_tech_bootcamp.community.controller;
 
 import kakao_tech_bootcamp.community.common.ApiResponse;
 import kakao_tech_bootcamp.community.dto.AuthRequestDto;
+import kakao_tech_bootcamp.community.service.AuthInfo;
 import kakao_tech_bootcamp.community.service.AuthStrategy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,6 +10,8 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
@@ -48,5 +51,11 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK)
                 .header(SET_COOKIE, cookie.toString())
                 .body(ApiResponse.success());
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Map<String, AuthInfo>>> validate(@CookieValue("sid") String sessionId) {
+        AuthInfo session = authStrategy.validate(sessionId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(Map.of("auth", session)));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/AuthSessionStrategy.java
@@ -51,9 +51,6 @@ public class AuthSessionStrategy implements AuthStrategy {
         String sessionId = UUID.randomUUID().toString();
         AuthInfo session = new AuthInfo(member.getId());
 
-        // NOTE: 프론트 서버에서 회원 정보를 알아내기 위해 memberId 추가
-        sessionId += "_" + member.getId();
-
         sessionRepository.save(sessionId, session);
 
         return sessionId;


### PR DESCRIPTION
## 작업 내용

- sid 쿠키 값 구조 변경: `{UUID}_{memberId}` → `{UUID}`
- 인증 정보 검증하는 GET /auth API 생성